### PR TITLE
Create Tripal Logger documentation

### DIFF
--- a/docs/dev_guide/module_dev.rst
+++ b/docs/dev_guide/module_dev.rst
@@ -13,6 +13,7 @@ Custom Module Development
    module_dev/entities
    module_dev/fields
    module_dev/forms
+   module_dev/logging
    module_dev/views
    module_dev/config
    module_dev/theme

--- a/docs/dev_guide/module_dev/logging.rst
+++ b/docs/dev_guide/module_dev/logging.rst
@@ -1,0 +1,40 @@
+
+Error Reporting and Logging
+===========================
+
+Tripal Logger
+-------------
+
+The Tripal logger service can be used to report status and errors to both the site user and to site administrators through the server log. A basic example is
+
+.. code-block:: php
+
+  $logger = \Drupal::service('tripal.logger');
+  $logger->notice('Hello world');
+  $logger->error('Hello world');
+
+There are eight levels of logging available. In order of increasing severity they are:
+`debug`, `info`, `notice`, `warning`, `error`, `critical`, `alert`, `emergency`
+
+The log message can be a simple quoted PHP string, or a string that utilizes placeholders. In the latter case, pass in an associative array of placeholder keys and values into the second parameter. For example:
+
+.. code-block:: php
+
+  $options = [];
+  $logger->warning('Error, status code @errornumber, error message @message', [
+    '@errornumber' => $resultcode,
+    '@message' => $errormessage,
+  ], $options);
+
+There are a few settings that can be passed in using the third ``$options`` parameter to control where the message is sent.
+
+  Use ``$options['drupal_set_message'] = TRUE;`` if you want the message to appear on the user's screen, default is ``FALSE``.
+
+  Use ``$options['logger'] = FALSE;`` if you do NOT want the message to go to the log at `/admin/reports/dblog`, default is ``TRUE``.
+
+For backwards compatibility with Tripal v3, the logger checks the ``TRIPAL_SUPPRESS_ERRORS`` environment variable. If it is defined with the value ``true`` (case insensitive), then all logging is suppressed even if it is not an "error" message.
+
+An additional pair of options is available for implementing progress bars. For the first message, set ``$options['is_progress_bar'] = TRUE;`` and ``$options['first_progress_bar'] = TRUE;``
+For subsequent updates to the progress bar, only set ``$options['is_progress_bar'] = TRUE;``
+It is likely for a progress bar that you will also want to include ``$options['logger'] = FALSE;`` to avoid overpopulating your server log.
+

--- a/docs/dev_guide/module_dev/logging.rst
+++ b/docs/dev_guide/module_dev/logging.rst
@@ -11,6 +11,7 @@ The Tripal logger service can be used to report status and errors to both the si
 
   $logger = \Drupal::service('tripal.logger');
   $logger->notice('Hello world');
+  $logger->warning('Hello world');
   $logger->error('Hello world');
 
 There are eight levels of logging available. In order of increasing severity they are:
@@ -21,7 +22,7 @@ The log message can be a simple quoted PHP string, or a string that utilizes pla
 .. code-block:: php
 
   $options = [];
-  $logger->warning('Error, status code @errornumber, error message @message', [
+  $logger->error('Error, status code @errornumber, error message @message', [
     '@errornumber' => $resultcode,
     '@message' => $errormessage,
   ], $options);
@@ -32,7 +33,7 @@ There are a few settings that can be passed in using the third ``$options`` para
 
   Use ``$options['logger'] = FALSE;`` if you do NOT want the message to go to the log at `/admin/reports/dblog`, default is ``TRUE``.
 
-For backwards compatibility with Tripal v3, the logger checks the ``TRIPAL_SUPPRESS_ERRORS`` environment variable. If it is defined with the value ``true`` (case insensitive), then all logging is suppressed even if it is not an "error" message.
+The logger checks the ``TRIPAL_SUPPRESS_ERRORS`` environment variable. If it is defined with the value ``true`` (case insensitive), then all logging is suppressed even if it is not an "error" message. This is generally only used for automated testing to prevent output from being printed.
 
 An additional pair of options is available for implementing progress bars. For the first message, set ``$options['is_progress_bar'] = TRUE;`` and ``$options['first_progress_bar'] = TRUE;``
 For subsequent updates to the progress bar, only set ``$options['is_progress_bar'] = TRUE;``

--- a/docs/upgrade_guide/module_dev.rst
+++ b/docs/upgrade_guide/module_dev.rst
@@ -7,16 +7,15 @@ This page provides useful short snippets of code to help module developers upgra
 tripal_set_message() and tripal_report_error()
 ---------------------------------------------------
 
-These functions have been upgraded and thus can be used as is. However, the new way is use a logger service as shown below.
+These functions have been upgraded and thus can be used as is. However, the new way is to use a logger service. For example:
 
 .. code-block:: php
 
   $logger = \Drupal::service('tripal.logger');
   $logger->notice('Hello world');
-  $logger->info('Hello world');
-  $logger->warning('Hello world');
   $logger->error('Hello world');
-  $logger->debug('Hello world');
+
+For more detailed information see the :ref:`Tripal Logger` documentation.
 
 drupal_set_message()
 ----------------------
@@ -31,16 +30,16 @@ Changelog: https://www.drupal.org/node/2774931
 
   // Add specific type of message within classes.
   $this->messenger->addMessage('Hello world', 'custom');
-  $this->messenger->addError('Hello world');
   $this->messenger->addStatus('Hello world');
   $this->messenger->addWarning('Hello world');
+  $this->messenger->addError('Hello world');
 
   // In procedural code:
   $messenger = \Drupal::messenger();
   $messenger->addMessage('Hello world', 'custom');
-  $messenger->addError('Hello world');
   $messenger->addStatus('Hello world');
   $messenger->addWarning('Hello world');
+  $messenger->addError('Hello world');
 
 format_date()
 -------------


### PR DESCRIPTION
This creates a new section for documenting how to log status messages and errors using the Tripal logger service. It is inspired by Tripal issue https://github.com/tripal/tripal/issues/1581

The existing section on migrating `tripal_set_message()` and `tripal_report_error()` is now a basic example, and then points to this new documention section.

