### PR TITLE
Drupal 9 end of life

### DIFF
--- a/docs/contributing/docker-for-testing.rst
+++ b/docs/contributing/docker-for-testing.rst
@@ -29,7 +29,7 @@ Testing an unmerged pull request
 
     .. code::
 
-      sudo docker build --tag=tripaldocker:testing-9999 --build-arg drupalversion="9.5.x-dev" --file tripaldocker/Dockerfile-php8.1-pgsql13 ./
+      sudo docker build --tag=tripaldocker:testing-9999 --build-arg drupalversion="10.1.x-dev" --file tripaldocker/Dockerfile-php8.1-pgsql13 ./
 
 6. We will now create a running docker container from this image, and map the web port to a value available on the test system.
 

--- a/docs/design/pending/entities-fields.rst
+++ b/docs/design/pending/entities-fields.rst
@@ -2,7 +2,7 @@
 Entities and Fields Design
 ============================
 
-This design document is attempting to describe our current design process for Entities and Fields in Tripal 4 utilizing the new Drupal 9 APIs.
+This design document is attempting to describe our current design process for Entities and Fields in Tripal 4 utilizing the new Drupal 10 APIs.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/design/pending/entities-fields/requirements.rst
+++ b/docs/design/pending/entities-fields/requirements.rst
@@ -8,7 +8,7 @@ The following are the requirements we are taking into account for our design. Pl
 
 Tripal needs to **support multiple data backends on a single Tripal Entity Type; specifically, on a per field basis.**. For example, a SNP entity type should be able to have data from Drupal (application-specific), Chado (biological metadata-specific), VCF (genotypic data), genetic map files, GWAS-related files, etc. This ensures that biological data can be stored in the format which most makes sense for that data whether that be a flat-file format or a database. Furthermore, it reduces data duplication by allowing support for original file formats rather then requiring all data to be imported into a single database.
 
-Unfortunately this requirement is in direct conflict with the new Drupal 9 paradigm of requiring a single data backend per entity type. All existing extension modules are in keeping with this Drupal paradigm (including `External Entities <https://www.drupal.org/project/external_entities>`_). Since this assumption is interwoven in many of the Entity and Content Entity classes, we cannot simply extend the core classes for our design.
+Unfortunately this requirement is in direct conflict with the new Drupal 9+ paradigm of requiring a single data backend per entity type. All existing extension modules are in keeping with this Drupal paradigm (including `External Entities <https://www.drupal.org/project/external_entities>`_). Since this assumption is interwoven in many of the Entity and Content Entity classes, we cannot simply extend the core classes for our design.
 
 2. Tripal Fields control their own data load + save
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/install/docker.rst
+++ b/docs/install/docker.rst
@@ -31,7 +31,7 @@ Quickstart
 
     .. code::
 
-      docker run --publish=9000:80 --name=t4 -tid --volume=$(pwd):/var/www/drupal10/web/modules/contrib/my_module tripalproject/tripaldocker:latest
+      docker run --publish=9000:80 --name=t4 -tid --volume=$(pwd):/var/www/drupal/web/modules/contrib/my_module tripalproject/tripaldocker:latest
 
 2. Start the PostgreSQL database.
 
@@ -59,7 +59,7 @@ Usage
 
    .. code::
 
-    docker exec --workdir=/var/www/drupal10/web/modules/contrib/tripal t4 phpunit
+    docker exec --workdir=/var/www/drupal/web/modules/contrib/tripal t4 phpunit
 
  - Open PSQL to query the database on the command line. The password is docker.
 
@@ -120,7 +120,7 @@ Using Latest tagged version
   .. code-block:: bash
 
     cd t4
-    docker run --publish=9000:80 --name=t4 -tid --volume=$(pwd):/var/www/drupal10/web/modules/contrib/tripal tripalproject/tripaldocker:latest
+    docker run --publish=9000:80 --name=t4 -tid --volume=$(pwd):/var/www/drupal/web/modules/contrib/tripal tripalproject/tripaldocker:latest
 
   The first time you run this command you will see ``Unable to find image 'tripalproject/tripaldocker:latest' locally``. This is not an error! It's just a warning and the command will automatically pull the image from the docker cloud.
 
@@ -137,7 +137,7 @@ Using Latest tagged version
 
    .. code-block:: bash
 
-    docker run --publish=9000:80 --name=t4 -tid --volume=C:\Users\yourusername\Dockers\t4:/var/www/drupal10/web/modules/contrib/tripal tripalproject/tripaldocker:latest``
+    docker run --publish=9000:80 --name=t4 -tid --volume=C:\Users\yourusername\Dockers\t4:/var/www/drupal/web/modules/contrib/tripal tripalproject/tripaldocker:latest``
 
 5. Start the PostgreSQL database.
 
@@ -198,8 +198,8 @@ On my web browser, I got the message "The provided host name is not valid for th
 
 .. code::
 
-  docker exec -it t4 chmod +w /var/www/drupal10/web/sites/default/settings.php
-  docker exec -it t4 vi /var/www/drupal10/web/sites/default/settings.php
+  docker exec -it t4 chmod +w /var/www/drupal/web/sites/default/settings.php
+  docker exec -it t4 vi /var/www/drupal/web/sites/default/settings.php
 
 For instance, if your server name is ``www.yourservername.org``:
 
@@ -241,7 +241,7 @@ To enable Xdebug, issue the following command:
 
 .. code::
 
-  docker exec --workdir=/var/www/drupal10/web/modules/contrib/tripal t4 xdebug_toggle.sh
+  docker exec --workdir=/var/www/drupal/web/modules/contrib/tripal t4 xdebug_toggle.sh
 
 This will toggle the Xdebug configuration file and restart Apache. You should use this command to disable Xdebug if it is enabled prior to running PHPUnit Tests as it seriously impacts test run duration (approximately 8 times longer).
 
@@ -269,7 +269,7 @@ A new configuration should be made using PHP. The following options can be used 
             "type": "php",
             "request": "launch",
             "port": 9003,
-            "pathMappings": { "/var/www/drupal10/web/modules/contrib/tripal": "~/Dockers/t4" }
+            "pathMappings": { "/var/www/drupal/web/modules/contrib/tripal": "~/Dockers/t4" }
         }
     ]
   }

--- a/docs/install/docker.rst
+++ b/docs/install/docker.rst
@@ -8,13 +8,13 @@ Software Stack
 
 Currently we have the following installed:
  - Debian Bullseye(11)
- - PHP 8.0.21 with extensions needed for Drupal (Memory limit 1028M)
- - Apache 2.4.54
- - PostgreSQL 13.7 (Debian 13.7-0+deb11u1)
- - Composer 2.3.10
- - Drush 11.1.1
- - Drupal 9.3.x-dev downloaded using composer (or as specified by drupalversion argument).
- - Xdebug 3.0.1
+ - PHP 8.2.12 with extensions needed for Drupal (Memory limit 1028M)
+ - Apache 2.4.56
+ - PostgreSQL 13.11 (Debian 13.11-0+deb11u1)
+ - Composer 2.6.5
+ - Drush 12.4.2
+ - Drupal 10.1.x-dev downloaded using composer (or as specified by drupalversion argument).
+ - Xdebug 3.2.1
 
 Quickstart
 ----------
@@ -31,7 +31,7 @@ Quickstart
 
     .. code::
 
-      docker run --publish=9000:80 --name=t4 -tid --volume=$(pwd):/var/www/drupal9/web/modules/contrib/my_module tripalproject/tripaldocker:latest
+      docker run --publish=9000:80 --name=t4 -tid --volume=$(pwd):/var/www/drupal10/web/modules/contrib/my_module tripalproject/tripaldocker:latest
 
 2. Start the PostgreSQL database.
 
@@ -59,7 +59,7 @@ Usage
 
    .. code::
 
-    docker exec --workdir=/var/www/drupal9/web/modules/contrib/tripal t4 phpunit
+    docker exec --workdir=/var/www/drupal10/web/modules/contrib/tripal t4 phpunit
 
  - Open PSQL to query the database on the command line. The password is docker.
 
@@ -120,7 +120,7 @@ Using Latest tagged version
   .. code-block:: bash
 
     cd t4
-    docker run --publish=9000:80 --name=t4 -tid --volume=$(pwd):/var/www/drupal9/web/modules/contrib/tripal tripalproject/tripaldocker:latest
+    docker run --publish=9000:80 --name=t4 -tid --volume=$(pwd):/var/www/drupal10/web/modules/contrib/tripal tripalproject/tripaldocker:latest
 
   The first time you run this command you will see ``Unable to find image 'tripalproject/tripaldocker:latest' locally``. This is not an error! It's just a warning and the command will automatically pull the image from the docker cloud.
 
@@ -137,7 +137,7 @@ Using Latest tagged version
 
    .. code-block:: bash
 
-    docker run --publish=9000:80 --name=t4 -tid --volume=C:\Users\yourusername\Dockers\t4:/var/www/drupal9/web/modules/contrib/tripal tripalproject/tripaldocker:latest``
+    docker run --publish=9000:80 --name=t4 -tid --volume=C:\Users\yourusername\Dockers\t4:/var/www/drupal10/web/modules/contrib/tripal tripalproject/tripaldocker:latest``
 
 5. Start the PostgreSQL database.
 
@@ -168,7 +168,7 @@ Next, you use the `docker build <https://docs.docker.com/engine/reference/comman
 .. code-block:: bash
 
   cd t4
-  docker build --tag=tripalproject/tripaldocker:drupal9.1.x-dev --build-arg drupalversion='9.1.x-dev' ./
+  docker build --tag=tripalproject/tripaldocker:drupal10.1.x-dev --build-arg drupalversion='10.1.x-dev' ./
 
 This process will take a fair amount of time as it completely installs Drupal, Tripal and PostgreSQL. You will see a large amount of red text but hopefully not any errors. You should always test the image by running it before pushing it up to docker hub!
 
@@ -198,8 +198,8 @@ On my web browser, I got the message "The provided host name is not valid for th
 
 .. code::
 
-  docker exec -it t4 chmod +w /var/www/drupal9/web/sites/default/settings.php
-  docker exec -it t4 vi /var/www/drupal9/web/sites/default/settings.php
+  docker exec -it t4 chmod +w /var/www/drupal10/web/sites/default/settings.php
+  docker exec -it t4 vi /var/www/drupal10/web/sites/default/settings.php
 
 For instance, if your server name is ``www.yourservername.org``:
 
@@ -241,7 +241,7 @@ To enable Xdebug, issue the following command:
 
 .. code::
 
-  docker exec --workdir=/var/www/drupal9/web/modules/contrib/tripal t4 xdebug_toggle.sh
+  docker exec --workdir=/var/www/drupal10/web/modules/contrib/tripal t4 xdebug_toggle.sh
 
 This will toggle the Xdebug configuration file and restart Apache. You should use this command to disable Xdebug if it is enabled prior to running PHPUnit Tests as it seriously impacts test run duration (approximately 8 times longer).
 
@@ -269,7 +269,7 @@ A new configuration should be made using PHP. The following options can be used 
             "type": "php",
             "request": "launch",
             "port": 9003,
-            "pathMappings": { "/var/www/drupal9/web/modules/contrib/tripal": "~/Dockers/t4" }
+            "pathMappings": { "/var/www/drupal10/web/modules/contrib/tripal": "~/Dockers/t4" }
         }
     ]
   }

--- a/docs/install/requirements.rst
+++ b/docs/install/requirements.rst
@@ -16,27 +16,19 @@ Supported Drupal Versions
 The following table shows the current status of automated testing on the versions
 of Drupal we currently support.
 
-=========== ============ ============== ============== ============== ================
-Drupal      9.2.x        9.3.x          9.4.x          9.5.x          10.0.x
-=========== ============ ============== ============== ============== ================
-**PHP 8.0** |PHP8D9.2.x| |PHP8D9.3.x|   |PHP8D9.4.x|   |PHP8D9.5.x|
-**PHP 8.1**              |PHP8.1D9.3.x| |PHP8.1D9.4.x| |PHP8.1D9.5.x| |PHP8.1D10.0.x|
-=========== ============ ============== ============== ============== ================
+=========== ================ ================
+Drupal      10.0.x           10.1.x
+=========== ================ ================
+**PHP 8.1** |PHP8.1D10.0.x|  |PHP8.1D10.1.x|
+**PHP 8.2** |PHP8.2D10.0.x|  |PHP8.2D10.1.x|
+=========== ================ ================
 
 
-.. |PHP8D9.2.x| image:: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8_D9_2x.yml/badge.svg
-   :target: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8_D9_2x.yml
-.. |PHP8D9.3.x| image:: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8_D9_3x.yml/badge.svg
-   :target: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8_D9_3x.yml
-.. |PHP8D9.4.x| image:: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8_D9_4x.yml/badge.svg
-   :target: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8_D9_4x.yml
-.. |PHP8D9.5.x| image:: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8_D9_5x.yml/badge.svg
-   :target: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8_D9_5x.yml
-.. |PHP8.1D9.3.x| image:: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.1_D9_3x.yml/badge.svg
-   :target: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.1_D9_3x.yml
-.. |PHP8.1D9.4.x| image:: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.1_D9_4x.yml/badge.svg
-   :target: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.1_D9_4x.yml
-.. |PHP8.1D9.5.x| image:: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.1_D9_5x.yml/badge.svg
-   :target: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.1_D9_5x.yml
 .. |PHP8.1D10.0.x| image:: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.1_D10_0x.yml/badge.svg
    :target: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.1_D10_0x.yml
+.. |PHP8.1D10.1.x| image:: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.1_D10_1x.yml/badge.svg
+   :target: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.1_D10_1x.yml
+.. |PHP8.2D10.0.x| image:: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.2_D10_0x.yml/badge.svg
+   :target: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.2_D10_0x.yml
+.. |PHP8.2D10.1.x| image:: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.2_D10_1x.yml/badge.svg
+   :target: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.2_D10_1x.yml

--- a/docs/upgrade_guide/module_dev.rst
+++ b/docs/upgrade_guide/module_dev.rst
@@ -2,7 +2,7 @@
 Upgrading an Extension Module
 ================================
 
-This page provides useful short snippets of code to help module developers upgrade their Tripal v3 compatible modules to work with Drupal 8/9. This list is not comprehensive or complete, but is meant to be an aid.
+This page provides useful short snippets of code to help module developers upgrade their Tripal v3 compatible modules to work with Drupal 10. This list is not comprehensive or complete, but is meant to be an aid.
 
 tripal_set_message() and tripal_report_error()
 ---------------------------------------------------
@@ -74,7 +74,7 @@ To create HTML links the Drupal 7 was was:
   $link = l('Administration', '/admin')
 
 
-The Drupal 9 approach is:
+The Drupal 10 approach is:
 
 .. code-block:: php
 
@@ -214,7 +214,7 @@ In Drupal 8 use code similar to the following to embed a view on a page:
 
 Attaching CSS
 -------------
-In Drupal 8/9 CSS files are part of "libraries".  Libraries are groups of "assets" such as CSS, JS, or other resources needed for a particular set of pages that the module provides.  Libraries are defined in the `<module_name>.libraries.yml` file.  For information about preparing your CSS files with drupal see the page about `adding css and js files to a module <https://www.drupal.org/node/2274843>`_.  Once the CSS is setup correctly, you want to add "libraries" to pages that use them.  This is done by adding an '#attached' element to the render array returned by a page using the following form:
+In Drupal 10 CSS files are part of "libraries".  Libraries are groups of "assets" such as CSS, JS, or other resources needed for a particular set of pages that the module provides.  Libraries are defined in the `<module_name>.libraries.yml` file.  For information about preparing your CSS files with drupal see the page about `adding css and js files to a module <https://www.drupal.org/node/2274843>`_.  Once the CSS is setup correctly, you want to add "libraries" to pages that use them.  This is done by adding an '#attached' element to the render array returned by a page using the following form:
 
 .. code-block:: php
 


### PR DESCRIPTION
Issue #44
This removes documentation, references, and examples using Drupal 9, which is now end-of-life.
See Tripal issue https://github.com/tripal/tripal/issues/1673 and PR https://github.com/tripal/tripal/issues/1681