### PR TITLE
Make naming conventions for fields clearer

### DIFF
--- a/docs/dev_guide/module_dev/fields.rst
+++ b/docs/dev_guide/module_dev/fields.rst
@@ -133,16 +133,29 @@ The filename for your new field should adhere to the following schema. Please no
 Within the individual files, in the annotation section, the ID also has to follow 
 a specific format, and would look like the following:
 
-  +------------------+----------------------------+
-  | File             | ID within annotation       |
-  +==================+============================+
-  | Type             | my_field_default           |
-  +------------------+----------------------------+
-  | Formatter        | my_field_formatter_default |
-  +------------------+----------------------------+
-  | Widget           | my_field_widget_default    |
-  +------------------+----------------------------+ 
+  .. table:: Tripal Core modules:
 
+    +------------------+----------------------------+
+    | File             | ID within annotation       |
+    +==================+============================+
+    | Type             | my_field_type_default      |
+    +------------------+----------------------------+
+    | Formatter        | my_field_formatter_default |
+    +------------------+----------------------------+
+    | Widget           | my_field_widget_default    |
+    +------------------+----------------------------+ 
+
+  .. table:: Extension modules:
+
+    +------------------+----------------------------+
+    | File             | ID within annotation       |
+    +==================+============================+
+    | Type             | my_field_type              |
+    +------------------+----------------------------+
+    | Formatter        | my_field_formatter         |
+    +------------------+----------------------------+
+    | Widget           | my_field_widget            |
+    +------------------+----------------------------+ 
 
 About the Storage Backend
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/dev_guide/module_dev/fields.rst
+++ b/docs/dev_guide/module_dev/fields.rst
@@ -104,19 +104,31 @@ Note that the file name must match the class name.
 Naming convention
 ^^^^^^^^^^^^^^^^^
 
-The filename for your new field should adhere to the following schema. Please note the casing
-used. In addition, for fields that will be included in Tripal Core, note the 'Default'
-designation:
+The filename for your new field should adhere to the following schema. Please note the casing used. In addition, for fields that will be included in Tripal Core, note the 'Default' designation, any fields added by extension modules should **not** use 'Default':
 
-  +------------------+-----------------------------+
-  | File             | Filename                    |
-  +==================+=============================+
-  | Type             | MyFieldTypeDefault.php      |
-  +------------------+-----------------------------+
-  | Formatter        | MyFieldFormatterDefault.php |
-  +------------------+-----------------------------+
-  | Widget           | MyFieldWidgetDefault.php    |
-  +------------------+-----------------------------+ 
+  .. table:: Tripal Core modules:
+
+    +------------------+-----------------------------+
+    | File             | Filename                    |
+    +==================+=============================+
+    | Type             | MyFieldTypeDefault.php      |
+    +------------------+-----------------------------+
+    | Formatter        | MyFieldFormatterDefault.php |
+    +------------------+-----------------------------+
+    | Widget           | MyFieldWidgetDefault.php    |
+    +------------------+-----------------------------+
+
+  .. table:: Extension modules:
+
+    +------------------+-----------------------------+
+    | File             | Filename                    |
+    +==================+=============================+
+    | Type             | MyFieldType.php             |
+    +------------------+-----------------------------+
+    | Formatter        | MyFieldFormatter.php        |
+    +------------------+-----------------------------+
+    | Widget           | MyFieldWidget.php           |
+    +------------------+-----------------------------+ 
 
 Within the individual files, in the annotation section, the ID also has to follow 
 a specific format, and would look like the following:


### PR DESCRIPTION
Delineate more carefully between fields from core or extension modules

Should satisfy the comments by @laceysanderson and @spficklin here: https://github.com/tripal/tripal_doc/issues/27 and here https://github.com/tripal/tripal_doc/pull/28