### PR TITLE
Update supported Drupal versions (Drop 10.0 and 10.1)

### DIFF
--- a/docs/install/requirements.rst
+++ b/docs/install/requirements.rst
@@ -4,7 +4,7 @@ Requirements
 
 - Drupal (see supported versions below)
 - Drupal core modules: Search, Path, Views, and Field.
-- PostgreSQL 12+
+- PostgreSQL 13+
 - PHP 8 (tested with 8.1, 8.2, 8.3)
 - Apache 2+
 - Composer 2+
@@ -22,23 +22,14 @@ Supported Drupal Versions
 The following table shows the current status of automated testing on the versions
 of Drupal we currently support.
 
-=========== ================ ================ ================
-Drupal      10.0.x           10.1.x           10.2.x
-=========== ================ ================ ================
-**PHP 8.1** |PHP8.1D10.0.x|  |PHP8.1D10.1.x|  |PHP8.1D10.2.x|
-**PHP 8.2** |PHP8.2D10.0.x|  |PHP8.2D10.1.x|  |PHP8.2D10.2.x|
-**PHP 8.3**                                   |PHP8.3D10.2.x|
-=========== ================ ================ ================
+=========== ================ ================
+Drupal      10.2.x           10.3.x
+=========== ================ ================
+**PHP 8.1** |PHP8.1D10.2.x|  |PHP8.1D10.3.x|
+**PHP 8.2** |PHP8.2D10.2.x|  |PHP8.2D10.3.x|
+**PHP 8.3** |PHP8.3D10.2.x|  |PHP8.3D10.3.x|
+=========== ================ ================
 
-
-.. |PHP8.1D10.0.x| image:: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.1_D10_0x.yml/badge.svg
-   :target: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.1_D10_0x.yml
-.. |PHP8.1D10.1.x| image:: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.1_D10_1x.yml/badge.svg
-   :target: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.1_D10_1x.yml
-.. |PHP8.2D10.0.x| image:: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.2_D10_0x.yml/badge.svg
-   :target: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.2_D10_0x.yml
-.. |PHP8.2D10.1.x| image:: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.2_D10_1x.yml/badge.svg
-   :target: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.2_D10_1x.yml
 
 .. |PHP8.1D10.2.x| image:: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.1_D10_2x.yml/badge.svg
    :target: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.1_D10_2x.yml
@@ -46,3 +37,10 @@ Drupal      10.0.x           10.1.x           10.2.x
    :target: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.2_D10_2x.yml
 .. |PHP8.3D10.2.x| image:: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.3_D10_2x.yml/badge.svg
    :target: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.3_D10_2x.yml
+
+.. |PHP8.1D10.3.x| image:: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.1_D10_3x.yml/badge.svg
+   :target: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.1_D10_3x.yml
+.. |PHP8.2D10.3.x| image:: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.2_D10_3x.yml/badge.svg
+   :target: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.2_D10_3x.yml
+.. |PHP8.3D10.3.x| image:: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.3_D10_3x.yml/badge.svg
+   :target: https://github.com/tripal/tripal/actions/workflows/MAIN-phpunit-php8.3_D10_3x.yml


### PR DESCRIPTION
Tripal issue https://github.com/tripal/tripal/issues/1897 will drop support for Drupal 10.0, and 10.1
Tripal issue https://github.com/tripal/tripal/issues/1888 added support for Drupal 10.3

This PR will adjust the docs accordingly
I also changed the minimum Postgresql version from 12 to 13, simply because we don't test on 12.
Plus, PostgreSQL 12 will stop receiving fixes on November 14, 2024.