### PR TITLE
Copyright year not hardcoded

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,7 @@ from sphinx.highlighting import lexers
 from pygments.lexers.web import PhpLexer
 lexers["php"] = PhpLexer(startinline=True, linenos=1)
 lexers["php-annotations"] = PhpLexer(startinline=True, linenos=1)
+import time
 
 # -- Path setup --------------------------------------------------------------
 
@@ -28,13 +29,13 @@ lexers["php-annotations"] = PhpLexer(startinline=True, linenos=1)
 # -- Project information -----------------------------------------------------
 
 project = u'Tripal'
-copyright = u'2023, Tripal Project Management Committee with the help of the Tripal Community'
+copyright = u'2009-%s, Tripal Project Management Committee with the help of the Tripal Community' % time.strftime('%Y')
 author = u'Tripal Project Management Committee with the help of the Tripal Community'
 
 # The short X.Y version
 version = u'4.x'
 # The full version, including alpha/beta/rc tags
-release = u'4.x.alpha.1'
+release = u'4.x.alpha.2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/dev_guide/deprecations.rst
+++ b/docs/dev_guide/deprecations.rst
@@ -96,8 +96,8 @@ Cross schema queries
   please add an issue on our github at 
   https://github.com/tripal/tripal_doc/issues !
 
-Additional Resources
---------------------
+Additional Deprecation Resources
+--------------------------------
 
  - `Official Drupal: db_* procedural functions of the Database API layer have been deprecated <https://www.drupal.org/node/2993033>`_
  - `Official Drupal: function db_select <https://api.drupal.org/api/drupal/core%21includes%21database.inc/function/db_select/8.9.x>`_

--- a/docs/dev_guide/module_dev.rst
+++ b/docs/dev_guide/module_dev.rst
@@ -11,6 +11,7 @@ Custom Module Development
    module_dev/file_structure
    module_dev/routing
    module_dev/entities
+   module_dev/buddies
    module_dev/fields
    module_dev/forms
    module_dev/jobs

--- a/docs/dev_guide/module_dev/buddies.rst
+++ b/docs/dev_guide/module_dev/buddies.rst
@@ -9,12 +9,15 @@ of data in several tables or simultaneous combinations of tables.
 All buddies are created by a two step process:
 
   1. Create the service. There is a single service that can be used for all buddies:
+
      ``$buddy_service = \Drupal::service('tripal_chado.chado_buddy');``
+
      For best practice, this service should be injected into your class.
      To see how to do this, see TBD
 
   2. Create an instance for each service you want, for example:
-     ``$instance = $buddy_service->createInstance('chado_dbxref_buddy', []);``
+
+     ``$dbxref_instance = $buddy_service->createInstance('chado_dbxref_buddy', []);``
 
 See the following sections for details on each buddy class.
 
@@ -22,7 +25,7 @@ See the following sections for details on each buddy class.
    :maxdepth: 2
    :caption: Contents:
 
+   buddies/buddy_values
    buddies/dbxref
    buddies/cvterm
    buddies/property
-

--- a/docs/dev_guide/module_dev/buddies.rst
+++ b/docs/dev_guide/module_dev/buddies.rst
@@ -13,7 +13,7 @@ All buddies are created by a two step process:
      ``$buddy_service = \Drupal::service('tripal_chado.chado_buddy');``
 
      For best practice, this service should be injected into your class.
-     To see how to do this, see TBD
+     To see how to do this, see :ref:`Injecting the Buddy Service`
 
   2. Create an instance for each service you want, for example:
 

--- a/docs/dev_guide/module_dev/buddies.rst
+++ b/docs/dev_guide/module_dev/buddies.rst
@@ -1,0 +1,28 @@
+
+Chado Buddies
+===============
+
+Chado Buddies are a group of classes that make accessing certain types of chado
+data as easy and as fast as possible. They allow retrieval, addition, and updating
+of data in several tables or simultaneous combinations of tables.
+
+All buddies are created by a two step process:
+
+  1. Create the service. There is a single service that can be used for all buddies:
+     ``$buddy_service = \Drupal::service('tripal_chado.chado_buddy');``
+     For best practice, this service should be injected into your class.
+     To see how to do this, see TBD
+
+  2. Create an instance for each service you want, for example:
+     ``$instance = $buddy_service->createInstance('chado_dbxref_buddy', []);``
+
+See the following sections for details on each buddy class.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   buddies/dbxref
+   buddies/cvterm
+   buddies/property
+

--- a/docs/dev_guide/module_dev/buddies.rst
+++ b/docs/dev_guide/module_dev/buddies.rst
@@ -29,3 +29,4 @@ See the following sections for details on each buddy class.
    buddies/dbxref
    buddies/cvterm
    buddies/property
+   buddies/inject

--- a/docs/dev_guide/module_dev/buddies/buddy_values.rst
+++ b/docs/dev_guide/module_dev/buddies/buddy_values.rst
@@ -11,6 +11,9 @@ For example, for the table ``db`` and column ``name``, the key would be ``db.nam
 This method prevents ambiguity when a buddy handles more than one table, and different tables
 may have the same column name, such as ``db.name`` and ``cv.name``.
 
+Any or all input values can be also be passed in using a ChadoBuddyRecord, using the key
+`buddy_record` in the values array.
+
 Chado Buddy Output Values
 ---------------------------
 
@@ -89,11 +92,13 @@ including a dbxref, and using that term to assign a property to a gene.
   if ($count != 1) {
     // This is unlikely, and you should catch exceptions as shown in example #3
   }
+  $cvterm_id = $chado_cvterm_record->getValue('cvterm.cvterm_id');
+  print "Created or found cvterm with id=$cvterm_id\n";
 
   // Create the property record in the featureprop table
   $feature_id = 1; // For this example a gene feature exists with this id
   $values = [
-    'featureprop.type_id' => $chado_cvterm_record->getValue('cvterm.cvterm_id'),
+    'buddy_record' => $chado_cvterm_record,
     'featureprop.value' => 'Example value of 2 for the property',
   ];
   $chado_property_record = $property_instance->upsertProperty('feature', $feature_id, $values, []);

--- a/docs/dev_guide/module_dev/buddies/buddy_values.rst
+++ b/docs/dev_guide/module_dev/buddies/buddy_values.rst
@@ -14,13 +14,17 @@ may have the same column name, such as ``db.name`` and ``cv.name``.
 Chado Buddy Output Values
 ---------------------------
 
-Most of the chado buddy functions return objects of the class ``ChadoBuddyRecord``.
-This class provides two functions to retrieve values.
+Most of the chado buddy functions return one or more objects of the class ``ChadoBuddyRecord``.
+An object of this class provides two functions to retrieve values:
 
-  1. ``$chado_buddy_records->getValues()`` - this function returns an associative array in the same format
+  1. ``$chado_buddy_record->getValues()`` - this function returns an associative array in the same format
      as was used to pass input data.
-  2. ``$chado_buddy_records->getValue($key)`` - this function returns a single value from the record.
-     If the passed key does not exist, a NULL is returned.
+  2. ``$chado_buddy_record->getValue($key, $options)`` - this function returns a single value from the record.
+     By default, if the passed key does not exist, an exception is thrown.
+     This strict mode can be disabled and a NULL will be returned instead.
+     Enable this lenient mode with:
+
+     ``$options = ['strict' => FALSE]``
 
 .. note::
 
@@ -30,8 +34,11 @@ This class provides two functions to retrieve values.
 
   It will return ``FALSE`` if no records matched the input values.
 
-The buddy class also provides a counting function for convenience in determining how many records were returned
-  ``$buddy_instance->countBuddies($chado_buddy_records)``
+The buddy class also provides a counting function for convenience in determining how many records were returned.
+For example:
+
+``$count = $buddy_instance->countBuddies($chado_buddy_records);``
+
 which will return an integer indicating how many records were returned.
 
 Chado Buddy Example #1
@@ -55,3 +62,75 @@ Here is a simple example to look up the ``db_id`` value of the ``local`` databas
       $db_id = $chado_buddy_records->getValue('db.db_id');
     }
   }
+  print "local db id=$db_id\n";
+
+Chado Buddy Example #2
+------------------------
+
+Here is a more advanced example of creating a new controlled vocabulary term,
+including a dbxref, and using that term to assign a property to a gene.
+
+.. code::
+
+  $buddy_service = \Drupal::service('tripal_chado.chado_buddy');
+  $cvterm_instance = $buddy_service->createInstance('chado_cvterm_buddy', []);
+  $property_instance = $buddy_service->createInstance('chado_property_buddy', []);
+
+  // Create the cvterm and dbxref records in chado, unless they already exist.
+  $values = [
+    'db.name' => 'local',
+    'cv.name' => 'local',
+    'dbxref.accession' => 'X000002',
+    'cvterm.name' => 'Example 2',
+    'cvterm.definition' => 'A fake ontology term for example #2',
+  ];
+  $chado_cvterm_record = $cvterm_instance->upsertCvterm($values, []);
+  $count = $cvterm_instance->countBuddies($chado_cvterm_record);
+  if ($count != 1) {
+    // This is unlikely, and you should catch exceptions as shown in example #3
+  }
+
+  // Create the property record in the featureprop table
+  $feature_id = 1; // For this example a gene feature exists with this id
+  $values = [
+    'featureprop.type_id' => $chado_cvterm_record->getValue('cvterm.cvterm_id'),
+    'featureprop.value' => 'Example value of 2 for the property',
+  ];
+  $chado_property_record = $property_instance->upsertProperty('feature', $feature_id, $values, []);
+  $featureprop_id = $chado_property_record->getValue('featureprop.featureprop_id');
+  print "Added property with id=$featureprop_id\n";
+
+Chado Buddy Example #3
+------------------------
+
+This is the same as example #2, but we enable a mode where we can create the
+cvterm and dbxref automatically if it does not already exist, as long as we
+have all the values required to do so. In addition, we catch any exceptions
+that may occur so we can handle them appropriately, for example, the database
+or CV names we supplied might not exist.
+
+.. code::
+
+  $buddy_service = \Drupal::service('tripal_chado.chado_buddy');
+  $property_instance = $buddy_service->createInstance('chado_property_buddy', []);
+
+  $values = [
+    'db.name' => 'local',
+    'cv.name' => 'local',
+    'dbxref.accession' => 'X000003',
+    'cvterm.name' => 'Example 3',
+    'cvterm.definition' => 'A fake ontology term for example #3',
+    'featureprop.value' => 'Example value of 3 for the property',
+  ];
+  $options = [
+    'create_cvterm' => TRUE,
+  ];
+  $feature_id = 1; // For this example a gene feature exists with this id
+  try {
+    $chado_property_record = $property_instance->upsertProperty('feature', $feature_id, $values, $options);
+  }
+  catch (\Exception $e) {
+    print $e->getMessage();
+  }
+  $featureprop_id = $chado_property_record->getValue('featureprop.featureprop_id');
+  print "Added property with id=$featureprop_id\n";

--- a/docs/dev_guide/module_dev/buddies/buddy_values.rst
+++ b/docs/dev_guide/module_dev/buddies/buddy_values.rst
@@ -1,4 +1,3 @@
-
 Buddy Parameters
 ==================
 

--- a/docs/dev_guide/module_dev/buddies/buddy_values.rst
+++ b/docs/dev_guide/module_dev/buddies/buddy_values.rst
@@ -1,0 +1,57 @@
+
+Buddy Parameters
+==================
+
+Chado Buddy Input Values
+--------------------------
+
+Values are passed to a buddy function through an associative array.
+The keys for this array are the chado table name and the table column name separated by a period.
+For example, for the table ``db`` and column ``name``, the key would be ``db.name``.
+This method prevents ambiguity when a buddy handles more than one table, and different tables
+may have the same column name, such as ``db.name`` and ``cv.name``.
+
+Chado Buddy Output Values
+---------------------------
+
+Most of the chado buddy functions return objects of the class ``ChadoBuddyRecord``.
+This class provides two functions to retrieve values.
+
+  1. ``$chado_buddy_records->getValues()`` - this function returns an associative array in the same format
+     as was used to pass input data.
+  2. ``$chado_buddy_records->getValue($key)`` - this function returns a single value from the record.
+     If the passed key does not exist, a NULL is returned.
+
+.. note::
+
+  A buddy function will return a single object of the ``ChadoBuddyRecord`` class if a single record is returned.
+
+  It will return an array of ``ChadoBuddyRecord`` objects if two or more records are returned.
+
+  It will return ``FALSE`` if no records matched the input values.
+
+The buddy class also provides a counting function for convenience in determining how many records were returned
+  ``$buddy_instance->countBuddies($chado_buddy_records)``
+which will return an integer indicating how many records were returned.
+
+Chado Buddy Example #1
+------------------------
+
+Here is a simple example to look up the ``db_id`` value of the ``local`` database record.
+
+.. code::
+
+  $buddy_service = \Drupal::service('tripal_chado.chado_buddy');
+  $dbxref_instance = $buddy_service->createInstance('chado_dbxref_buddy', []);
+
+  $chado_buddy_records = $dbxref_instance->getDb(['db.name' => 'local'], []);
+  $db_id = NULL;
+  if ($chado_buddy_records) {
+    // For demonstration, we can first check if this is an array
+    if (is_array($chado_buddy_records)) {
+      $db_id = $chado_buddy_records[0]->getValue('db.db_id');
+    }
+    else {
+      $db_id = $chado_buddy_records->getValue('db.db_id');
+    }
+  }

--- a/docs/dev_guide/module_dev/buddies/buddy_values.rst
+++ b/docs/dev_guide/module_dev/buddies/buddy_values.rst
@@ -11,7 +11,7 @@ This method prevents ambiguity when a buddy handles more than one table, and dif
 may have the same column name, such as ``db.name`` and ``cv.name``.
 
 Any or all input values can be also be passed in using a ChadoBuddyRecord, using the key
-`buddy_record` in the values array.
+``buddy_record`` in the values array.
 
 Chado Buddy Output Values
 ---------------------------
@@ -79,7 +79,8 @@ including a dbxref, and using that term to assign a property to a gene.
   print "Created or found cvterm with id=$cvterm_id\n";
 
   // Create the property record in the featureprop table
-  $feature_id = 1; // For this example a gene feature exists with this id
+  $feature_id = 1; // For this example, assume a gene feature already exists with this id
+  // Here we demonstrate passing all the cvterm values using a ChadoBuddyRecord
   $values = [
     'buddy_record' => $chado_cvterm_record,
     'featureprop.value' => 'Example value of 2 for the property',
@@ -110,10 +111,12 @@ or CV names we supplied might not exist.
     'cvterm.definition' => 'A fake ontology term for example #3',
     'featureprop.value' => 'Example value of 3 for the property',
   ];
+  // This option triggers the ability to create the term and dbxref automatically
   $options = [
     'create_cvterm' => TRUE,
   ];
-  $feature_id = 1; // For this example a gene feature exists with this id
+  $feature_id = 1; // For this example, assume a gene feature already exists with this id
+  // Catch exceptions in case anything goes wrong
   try {
     $chado_property_record = $property_instance->upsertProperty('feature', $feature_id, $values, $options);
   }

--- a/docs/dev_guide/module_dev/buddies/buddy_values.rst
+++ b/docs/dev_guide/module_dev/buddies/buddy_values.rst
@@ -16,7 +16,7 @@ Any or all input values can be also be passed in using a ChadoBuddyRecord, using
 Chado Buddy Output Values
 ---------------------------
 
-Most of the chado buddy functions return one or more objects of the class ``ChadoBuddyRecord``.
+Depending on the function, most of the chado buddy functions will return one or more objects of the class ``ChadoBuddyRecord``.
 An object of this class provides two functions to retrieve values:
 
   1. ``$chado_buddy_record->getValues()`` - this function returns an associative array in the same format
@@ -30,18 +30,10 @@ An object of this class provides two functions to retrieve values:
 
 .. note::
 
-  A buddy function will return a single object of the ``ChadoBuddyRecord`` class if a single record is returned.
+  For insert and update functions, the function will return a single object of the ``ChadoBuddyRecord`` class.
 
-  It will return an array of ``ChadoBuddyRecord`` objects if two or more records are returned.
-
-  It will return ``FALSE`` if no records matched the input values.
-
-The buddy class also provides a counting function for convenience in determining how many records were returned.
-For example:
-
-``$count = $buddy_instance->countBuddies($chado_buddy_records);``
-
-which will return an integer indicating how many records were returned.
+  For query functions, the function will return an array of ``ChadoBuddyRecord`` records. This array will be
+  empty if no records matched the input values, and can have one or more records if matches were found.
 
 Chado Buddy Example #1
 ------------------------
@@ -56,15 +48,9 @@ Here is a simple example to look up the ``db_id`` value of the ``local`` databas
   $chado_buddy_records = $dbxref_instance->getDb(['db.name' => 'local'], []);
   $db_id = NULL;
   if ($chado_buddy_records) {
-    // For demonstration, we can first check if this is an array
-    if (is_array($chado_buddy_records)) {
-      $db_id = $chado_buddy_records[0]->getValue('db.db_id');
-    }
-    else {
-      $db_id = $chado_buddy_records->getValue('db.db_id');
-    }
+    $db_id = $chado_buddy_records[0]->getValue('db.db_id');
+    print "local db id=$db_id\n";
   }
-  print "local db id=$db_id\n";
 
 Chado Buddy Example #2
 ------------------------
@@ -87,10 +73,8 @@ including a dbxref, and using that term to assign a property to a gene.
     'cvterm.definition' => 'A fake ontology term for example #2',
   ];
   $chado_cvterm_record = $cvterm_instance->upsertCvterm($values, []);
-  $count = $cvterm_instance->countBuddies($chado_cvterm_record);
-  if ($count != 1) {
-    // This is unlikely, and you should catch exceptions as shown in example #3
-  }
+  // if for any reason insert failed, an exception is thrown, so
+  // you should catch exceptions as shown in example #3
   $cvterm_id = $chado_cvterm_record->getValue('cvterm.cvterm_id');
   print "Created or found cvterm with id=$cvterm_id\n";
 

--- a/docs/dev_guide/module_dev/buddies/cvterm.rst
+++ b/docs/dev_guide/module_dev/buddies/cvterm.rst
@@ -4,8 +4,12 @@ Chado Cvterm Buddy
 
 This buddy has the class name ``ChadoCvtermBuddy`` and the instance name ``chado_cvterm_buddy``.
 
-This buddy deals with four chado tables,
-the ``db``, ``dbxref``, ``cv``, and ``cvterm`` tables.
+This buddy deals with five chado tables, the
+`db <https://laceysanderson.github.io/chado-docs/db/tables/db.html>`_,
+`dbxref <https://laceysanderson.github.io/chado-docs/db/tables/dbxref.html>`_,
+`cv <https://laceysanderson.github.io/chado-docs/cv/tables/cv.html>`_,
+`cvterm <https://laceysanderson.github.io/chado-docs/cv/tables/cvterm.html>`_,
+and `cvtermsynonym <https://laceysanderson.github.io/chado-docs/cv/tables/cvtermsynonym.html>`_ tables.
 
 This buddy provides the following functions:
 
@@ -229,6 +233,7 @@ Valid keys for ``$options``:
    want to automatically create a dbxref if one does not already exist.
 
 
+
 upsertCvterm()
 ^^^^^^^^^^^^^^^^
 
@@ -292,3 +297,85 @@ Valid keys for ``$options``:
   constraint, so a value is required.
 
 This function returns TRUE if successful.
+
+
+
+getCvtermSynonym()
+^^^^^^^^^^^^^^^^^^^^
+
+Retrieves one or more records from the chado `cvtermsynonym <https://laceysanderson.github.io/chado-docs/cv/tables/cvtermsynonym.html>`_ table.
+
+Usage: ``$chado_buddy_records = $cvterm_instance->getCvtermSynonym($conditions, $options);``
+
+Valid keys for ``$conditions`` are all of those specified
+for :ref:`getCvterm()` plus these additional keys:
+
+* ``cvtermsynonym.cvtermsynonym_id``
+* ``cvtermsynonym.cvterm_id``
+* ``cvtermsynonym.synonym``
+* ``cvtermsynonym.type_id``
+
+Valid settings for ``$options``:
+
+Same as for :ref:`getCvterm()`.
+
+
+
+insertCvtermSynonym()
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Inserts a new record into the chado `cvtermsynonym <https://laceysanderson.github.io/chado-docs/cv/tables/cvtermsynonym.html>`_ table.
+
+Usage: ``$chado_buddy_records = $cvterm_instance->getCvtermSynonym($conditions, $options);``
+
+Valid keys for ``$conditions`` are all of those specified
+for :ref:`insertCvterm()` plus these additional keys:
+
+* ``cvtermsynonym.cvterm_id``
+* ``cvtermsynonym.synonym``
+* ``cvtermsynonym.type_id``
+
+Valid settings for ``$options``:
+
+Same as for :ref:`insertCvterm()`.
+
+
+
+updateCvtermSynonym()
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Updates an existing record in the chado `cvtermsynonym <https://laceysanderson.github.io/chado-docs/cv/tables/cvtermsynonym.html>`_ table.
+
+Usage: ``$chado_buddy_records = $cvterm_instance->getCvtermSynonym($conditions, $options);``
+
+Valid keys for ``$conditions`` are all of those specified
+for :ref:`updateCvterm()` plus these additional keys:
+
+* ``cvtermsynonym.cvtermsynonym_id``
+* ``cvtermsynonym.cvterm_id``
+* ``cvtermsynonym.synonym``
+* ``cvtermsynonym.type_id``
+
+Valid settings for ``$options``:
+
+Same as for :ref:`updateCvterm()`.
+
+
+
+upsertCvtermSynonym()
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Updates a record if it exists, or inserts it if it does not, in the chado `cvtermsynonym <https://laceysanderson.github.io/chado-docs/cv/tables/cvtermsynonym.html>`_ table.
+
+Usage: ``$chado_buddy_records = $cvterm_instance->getCvtermSynonym($conditions, $options);``
+
+Valid keys for ``$conditions`` are all of those specified
+for :ref:`upsertCvterm()` plus these additional keys:
+
+* ``cvtermsynonym.cvterm_id`` Ⓠ
+* ``cvtermsynonym.synonym`` Ⓠ
+* ``cvtermsynonym.type_id``
+
+Valid settings for ``$options``:
+
+Same as for :ref:`upsertCvterm()`.

--- a/docs/dev_guide/module_dev/buddies/cvterm.rst
+++ b/docs/dev_guide/module_dev/buddies/cvterm.rst
@@ -1,0 +1,294 @@
+
+Chado Cvterm Buddy
+====================
+
+This buddy has the class name ``ChadoCvtermBuddy`` and the instance name ``chado_cvterm_buddy``.
+
+This buddy deals with four chado tables,
+the ``db``, ``dbxref``, ``cv``, and ``cvterm`` tables.
+
+This buddy provides the following functions:
+
+  .. table:: Chado Cvterm Buddy:
+
+    +------------------+-------------------+--------------------------+------------------------------+
+    | Type of          |                   |                          |                              |
+    | Function         | cv table          | cvterm table             | cvtermsynonym synonym        |
+    +==================+===================+==========================+==============================+
+    | Lookup           | :ref:`getCv()`    | :ref:`getCvterm()`       | :ref:`getCvtermSynonym()`    |
+    +------------------+-------------------+--------------------------+------------------------------+
+    | Insert           | :ref:`insertCv()` | :ref:`insertCvterm()`    | :ref:`insertCvtermSynonym()` |
+    +------------------+-------------------+--------------------------+------------------------------+
+    | Update           | :ref:`updateCv()` | :ref:`updateCvterm()`    | :ref:`updateCvtermSynonym()` |
+    +------------------+-------------------+--------------------------+------------------------------+
+    | Upsert           | :ref:`upsertCv()` | :ref:`upsertCvterm()`    | :ref:`upsertCvtermSynonym()` |
+    +------------------+-------------------+--------------------------+------------------------------+
+    | Associate        |                   | :ref:`associateCvterm()` |                              |
+    +------------------+-------------------+--------------------------+------------------------------+
+
+
+
+getCv()
+^^^^^^^^^
+
+Retrieves one or more records from the chado `cv <https://laceysanderson.github.io/chado-docs/cv/tables/cv.html>`_ table.
+
+Usage: ``$chado_buddy_records = $cvterm_instance->getCv($conditions, $options);``
+
+Valid keys for ``$conditions``:
+
+* ``cv.cv_id``
+* ``cv.name``
+* ``cv.definition``
+* ``buddy_record``
+
+Valid settings for ``$options``:
+
+* ``'case_insensitive' => key`` or ``'case_insensitive' => [key1, key2, ...]``
+  Any keys specified here will be queried without case sensitivity. For example
+
+  ``$cvterm_instance->getCv(['cv.name' => 'edam'], ['case_insensitive' => 'cv.name']);``
+
+  will return either 'edam' or 'EDAM' or both.
+
+
+
+insertCv()
+^^^^^^^^^^^^
+
+Inserts a new record into the chado `cv <https://laceysanderson.github.io/chado-docs/cv/tables/cv.html>`_ table.
+
+Usage: ``$chado_buddy_records = $cvterm_instance->insertCv($values, $options);``
+
+Valid keys for ``$values``:
+
+* ``cv.name``
+* ``cv.definition``
+* ``buddy_record``
+
+Required keys to insert a new record:
+
+* ``cv.name``
+
+
+
+updateCv()
+^^^^^^^^^^^^
+
+Updates an existing record in the chado `cv <https://laceysanderson.github.io/chado-docs/cv/tables/cv.html>`_ table.
+
+Usage: ``$chado_buddy_records = $cvterm_instance->updateCv($values, $conditions, $options);``
+
+Valid keys for ``$values`` and ``$conditions``:
+
+* ``cv.name``
+* ``cv.definition``
+* ``buddy_record``
+
+Valid keys for ``$conditions`` only:
+
+* ``cv.cv_id``
+
+
+
+upsertCv()
+^^^^^^^^^^^^
+
+Updates a record if it exists, or inserts it if it does not, in the chado `cv <https://laceysanderson.github.io/chado-docs/cv/tables/cv.html>`_ table.
+Only keys designated with a Ⓠ are used for the query to find the record to update if it already exists.
+
+Usage: ``$chado_buddy_records = $cvterm_instance->insertCv($values, $options);``
+
+Valid keys for ``$values``:
+
+* ``cv.name`` Ⓠ
+* ``cv.definition``
+* ``buddy_record``
+
+Required keys to upsert a new record:
+
+* ``cv.name``
+
+
+
+getCvterm()
+^^^^^^^^^^^^^
+
+Retrieves one or more records from the chado `cvterm <https://laceysanderson.github.io/chado-docs/cv/tables/cvterm.html>`_ table.
+
+Usage: ``$chado_buddy_records = $cvterm_instance->getCvterm($conditions, $options);``
+
+Valid keys for ``$conditions``:
+
+* ``db.db_id``
+* ``db.name``
+* ``db.description``
+* ``db.url``
+* ``db.urlprefix``
+* ``dbxref.dbxref_id``
+* ``dbxref.db_id``
+* ``dbxref.description``
+* ``dbxref.accession``
+* ``dbxref.version``
+* ``cv.cv_id``
+* ``cv.name``
+* ``cv.definition``
+* ``cvterm.cvterm_id``
+* ``cvterm.cv_id``
+* ``cvterm.name``
+* ``cvterm.definition``
+* ``cvterm.dbxref_id``
+* ``cvterm.is_obsolete``
+* ``cvterm.is_relationshiptype``
+* ``buddy_record``
+
+Valid settings for ``$options``:
+
+* ``'case_insensitive' => key`` or ``'case_insensitive' => [key1, key2, ...]``
+  Any keys specified here will be queried without case sensitivity, e.g. 'edam' == 'EDAM'
+
+
+
+insertCvterm()
+^^^^^^^^^^^^^^^^
+
+Inserts a new record into the chado `cvterm <https://laceysanderson.github.io/chado-docs/cv/tables/cvterm.html>`_ table.
+
+Usage: ``$chado_buddy_records = $cvterm_instance->insertCvterm($values, $options);``
+
+Valid keys for ``$values``:
+
+* ``db.db_id``
+* ``db.name``
+* ``db.description``
+* ``db.url``
+* ``db.urlprefix``
+* ``dbxref.dbxref_id``
+* ``dbxref.db_id``
+* ``dbxref.description``
+* ``dbxref.accession``
+* ``dbxref.version``
+* ``cv.cv_id``
+* ``cv.name``
+* ``cv.definition``
+* ``cvterm.cvterm_id``
+* ``cvterm.cv_id``
+* ``cvterm.name``
+* ``cvterm.definition``
+* ``cvterm.dbxref_id``
+* ``cvterm.is_obsolete``
+* ``cvterm.is_relationshiptype``
+* ``buddy_record``
+
+Required keys to insert a new record:
+
+* either ``db.db_id`` or ``dbxref.db_id`` or ``db.name``
+* either ``dbxref.dbxref_id`` or ``cvterm.dbxref_id`` or ``dbxref.accession``
+* either ``cv.cv_id`` or ``cvterm.cv_id`` or ``cv.name``
+* ``cvterm.name``
+
+
+
+updateCvterm()
+^^^^^^^^^^^^^^^^
+
+Updates an existing record in the chado `cvterm <https://laceysanderson.github.io/chado-docs/cv/tables/cvterm.html>`_ table.
+
+Usage: ``$chado_buddy_records = $cvterm_instance->updateCvterm($values, $conditions, $options);``
+
+Valid keys for ``$values`` and ``$conditions``:
+
+* ``dbxref.description``
+* ``dbxref.accession``
+* ``dbxref.version``
+* ``cvterm.cv_id``
+* ``cvterm.name``
+* ``cvterm.definition``
+* ``cvterm.dbxref_id``
+* ``cvterm.is_obsolete``
+* ``cvterm.is_relationshiptype``
+* ``buddy_record``
+
+Valid keys for ``$conditions`` only:
+
+* ``db.db_id``
+* ``db.name``
+* ``db.description``
+* ``db.url``
+* ``db.urlprefix``
+* ``dbxref.dbxref_id``
+* ``dbxref.db_id``
+* ``cv.cv_id``
+* ``cv.name``
+* ``cv.definition``
+* ``cvterm.cvterm_id``
+
+Valid keys for ``$options``:
+
+ * ``create_dbxref`` - set to FALSE (default TRUE) if you do not
+   want to automatically create a dbxref if one does not already exist.
+
+
+upsertCvterm()
+^^^^^^^^^^^^^^^^
+
+Updates a record if it exists, or inserts it if it does not, in the chado `cvterm <https://laceysanderson.github.io/chado-docs/cv/tables/cvterm.html>`_ table.
+Only keys designated with a Ⓠ are used for the query to find the record to update if it already exists.
+
+Usage: ``$chado_buddy_records = $cvterm_instance->insertCvterm($values, $options);``
+
+Valid keys for ``$values``:
+
+* ``db.db_id``
+* ``db.name`` Ⓠ
+* ``db.description``
+* ``db.url``
+* ``db.urlprefix``
+* ``dbxref.db_id`` Ⓠ
+* ``dbxref.description``
+* ``dbxref.accession`` Ⓠ
+* ``dbxref.version`` Ⓠ
+* ``cv.cv_id``
+* ``cv.name`` Ⓠ
+* ``cv.definition``
+* ``cvterm.cv_id`` Ⓠ
+* ``cvterm.name`` Ⓠ
+* ``cvterm.definition``
+* ``cvterm.dbxref_id`` Ⓠ
+* ``cvterm.is_obsolete`` Ⓠ
+* ``cvterm.is_relationshiptype``
+* ``buddy_record``
+
+Required keys to upsert a new record:
+
+* either ``db.db_id`` or ``dbxref.db_id`` or ``db.name``
+* either ``dbxref.dbxref_id`` or ``cvterm.dbxref_id`` or ``dbxref.accession``
+* either ``cv.cv_id`` or ``cvterm.cv_id`` or ``cv.name``
+* ``cvterm.name``
+
+
+
+associateCvterm()
+^^^^^^^^^^^^^^^^^^^
+
+Given an existing dbxref record, associate it with a record in a chado table using its linking table.
+Both the cvterm and the chado record indicated by $record_id must already exist.
+
+Usage: ``$boolean_result = $cvterm_instance->associateCvterm($base_table, $record_id, $cvterm, $options);``
+
+Parameter string ``$base_table`` is the base table for which the dbxref should be associated.
+For example, to associate a dbxref with a feature the base_table=``feature`` and dbxref_id is added to the
+``feature_dbxref`` table.
+
+Parameter integer ``$record_id`` is the primary key of the base_table to associate the dbxref with.
+
+Parameter ChadoBuddyRecord ``$cvterm`` is a record returned by one of the ``xxxCvterm()`` functions.
+
+Valid keys for ``$options``:
+
+* ``pkey`` Looking up the primary key for the base table is costly. If it is
+  known, then pass it in as this option for better performance.
+* Also pass in any other columns used in the linking table. Sometimes there is a NOT NULL
+  constraint, so a value is required.
+
+This function returns TRUE if successful.

--- a/docs/dev_guide/module_dev/buddies/cvterm.rst
+++ b/docs/dev_guide/module_dev/buddies/cvterm.rst
@@ -17,7 +17,7 @@ This buddy provides the following functions:
 
     +------------------+-------------------+--------------------------+------------------------------+
     | Type of          |                   |                          |                              |
-    | Function         | cv table          | cvterm table             | cvtermsynonym synonym        |
+    | Function         | cv table          | cvterm table             | cvtermsynonym table          |
     +==================+===================+==========================+==============================+
     | Lookup           | :ref:`getCv()`    | :ref:`getCvterm()`       | :ref:`getCvtermSynonym()`    |
     +------------------+-------------------+--------------------------+------------------------------+

--- a/docs/dev_guide/module_dev/buddies/cvterm.rst
+++ b/docs/dev_guide/module_dev/buddies/cvterm.rst
@@ -35,7 +35,8 @@ This buddy provides the following functions:
 getCv()
 ^^^^^^^^^
 
-Retrieves one or more records from the chado `cv <https://laceysanderson.github.io/chado-docs/cv/tables/cv.html>`_ table.
+Retrieves zero or more records from the chado `cv <https://laceysanderson.github.io/chado-docs/cv/tables/cv.html>`_ table,
+and returns an array of ChadoBuddyRecord records.
 
 Usage: ``$chado_buddy_records = $cvterm_instance->getCv($conditions, $options);``
 
@@ -60,7 +61,8 @@ Valid settings for ``$options``:
 insertCv()
 ^^^^^^^^^^^^
 
-Inserts a new record into the chado `cv <https://laceysanderson.github.io/chado-docs/cv/tables/cv.html>`_ table.
+Inserts a new record into the chado `cv <https://laceysanderson.github.io/chado-docs/cv/tables/cv.html>`_ table,
+and returns a ChadoBuddyRecord describing the inserted record.
 
 Usage: ``$chado_buddy_records = $cvterm_instance->insertCv($values, $options);``
 
@@ -79,7 +81,8 @@ Required keys to insert a new record:
 updateCv()
 ^^^^^^^^^^^^
 
-Updates an existing record in the chado `cv <https://laceysanderson.github.io/chado-docs/cv/tables/cv.html>`_ table.
+Updates an existing record in the chado `cv <https://laceysanderson.github.io/chado-docs/cv/tables/cv.html>`_ table,
+and returns a ChadoBuddyRecord describing the updated record.
 
 Usage: ``$chado_buddy_records = $cvterm_instance->updateCv($values, $conditions, $options);``
 
@@ -98,7 +101,8 @@ Valid keys for ``$conditions`` only:
 upsertCv()
 ^^^^^^^^^^^^
 
-Updates a record if it exists, or inserts it if it does not, in the chado `cv <https://laceysanderson.github.io/chado-docs/cv/tables/cv.html>`_ table.
+Updates a record if it exists, or inserts it if it does not, in the chado `cv <https://laceysanderson.github.io/chado-docs/cv/tables/cv.html>`_ table,
+and returns a ChadoBuddyRecord describing the updated record.
 Only keys designated with a Ⓠ are used for the query to find the record to update if it already exists.
 
 Usage: ``$chado_buddy_records = $cvterm_instance->insertCv($values, $options);``
@@ -118,7 +122,8 @@ Required keys to upsert a new record:
 getCvterm()
 ^^^^^^^^^^^^^
 
-Retrieves one or more records from the chado `cvterm <https://laceysanderson.github.io/chado-docs/cv/tables/cvterm.html>`_ table.
+Retrieves zero or more records from the chado `cvterm <https://laceysanderson.github.io/chado-docs/cv/tables/cvterm.html>`_ table,
+and returns an array of ChadoBuddyRecord records.
 
 Usage: ``$chado_buddy_records = $cvterm_instance->getCvterm($conditions, $options);``
 
@@ -156,7 +161,8 @@ Valid settings for ``$options``:
 insertCvterm()
 ^^^^^^^^^^^^^^^^
 
-Inserts a new record into the chado `cvterm <https://laceysanderson.github.io/chado-docs/cv/tables/cvterm.html>`_ table.
+Inserts a new record into the chado `cvterm <https://laceysanderson.github.io/chado-docs/cv/tables/cvterm.html>`_ table,
+and returns a ChadoBuddyRecord describing the updated record.
 
 Usage: ``$chado_buddy_records = $cvterm_instance->insertCvterm($values, $options);``
 
@@ -196,7 +202,8 @@ Required keys to insert a new record:
 updateCvterm()
 ^^^^^^^^^^^^^^^^
 
-Updates an existing record in the chado `cvterm <https://laceysanderson.github.io/chado-docs/cv/tables/cvterm.html>`_ table.
+Updates an existing record in the chado `cvterm <https://laceysanderson.github.io/chado-docs/cv/tables/cvterm.html>`_ table,
+and returns a ChadoBuddyRecord describing the updated record.
 
 Usage: ``$chado_buddy_records = $cvterm_instance->updateCvterm($values, $conditions, $options);``
 
@@ -237,7 +244,8 @@ Valid keys for ``$options``:
 upsertCvterm()
 ^^^^^^^^^^^^^^^^
 
-Updates a record if it exists, or inserts it if it does not, in the chado `cvterm <https://laceysanderson.github.io/chado-docs/cv/tables/cvterm.html>`_ table.
+Updates a record if it exists, or inserts it if it does not, in the chado `cvterm <https://laceysanderson.github.io/chado-docs/cv/tables/cvterm.html>`_ table,
+and returns a ChadoBuddyRecord describing the updated record.
 Only keys designated with a Ⓠ are used for the query to find the record to update if it already exists.
 
 Usage: ``$chado_buddy_records = $cvterm_instance->insertCvterm($values, $options);``
@@ -287,7 +295,7 @@ For example, to associate a dbxref with a feature the base_table=``feature`` and
 
 Parameter integer ``$record_id`` is the primary key of the base_table to associate the dbxref with.
 
-Parameter ChadoBuddyRecord ``$cvterm`` is a record returned by one of the ``xxxCvterm()`` functions.
+Parameter ChadoBuddyRecord ``$cvterm`` is a ChadoBuddyRecord returned by one of the ``xxxCvterm()`` functions.
 
 Valid keys for ``$options``:
 
@@ -303,7 +311,8 @@ This function returns TRUE if successful.
 getCvtermSynonym()
 ^^^^^^^^^^^^^^^^^^^^
 
-Retrieves one or more records from the chado `cvtermsynonym <https://laceysanderson.github.io/chado-docs/cv/tables/cvtermsynonym.html>`_ table.
+Retrieves zero or more records from the chado `cvtermsynonym <https://laceysanderson.github.io/chado-docs/cv/tables/cvtermsynonym.html>`_ table,
+and returns an array of ChadoBuddyRecord records.
 
 Usage: ``$chado_buddy_records = $cvterm_instance->getCvtermSynonym($conditions, $options);``
 
@@ -324,7 +333,8 @@ Same as for :ref:`getCvterm()`.
 insertCvtermSynonym()
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Inserts a new record into the chado `cvtermsynonym <https://laceysanderson.github.io/chado-docs/cv/tables/cvtermsynonym.html>`_ table.
+Inserts a new record into the chado `cvtermsynonym <https://laceysanderson.github.io/chado-docs/cv/tables/cvtermsynonym.html>`_ table,
+and returns a ChadoBuddyRecord describing the inserted record.
 
 Usage: ``$chado_buddy_records = $cvterm_instance->getCvtermSynonym($conditions, $options);``
 
@@ -344,7 +354,8 @@ Same as for :ref:`insertCvterm()`.
 updateCvtermSynonym()
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Updates an existing record in the chado `cvtermsynonym <https://laceysanderson.github.io/chado-docs/cv/tables/cvtermsynonym.html>`_ table.
+Updates an existing record in the chado `cvtermsynonym <https://laceysanderson.github.io/chado-docs/cv/tables/cvtermsynonym.html>`_ table,
+and returns a ChadoBuddyRecord describing the updated record.
 
 Usage: ``$chado_buddy_records = $cvterm_instance->getCvtermSynonym($conditions, $options);``
 
@@ -365,7 +376,8 @@ Same as for :ref:`updateCvterm()`.
 upsertCvtermSynonym()
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Updates a record if it exists, or inserts it if it does not, in the chado `cvtermsynonym <https://laceysanderson.github.io/chado-docs/cv/tables/cvtermsynonym.html>`_ table.
+Updates a record if it exists, or inserts it if it does not, in the chado `cvtermsynonym <https://laceysanderson.github.io/chado-docs/cv/tables/cvtermsynonym.html>`_ table,
+and returns a ChadoBuddyRecord describing the updated record.
 
 Usage: ``$chado_buddy_records = $cvterm_instance->getCvtermSynonym($conditions, $options);``
 

--- a/docs/dev_guide/module_dev/buddies/cvterm.rst
+++ b/docs/dev_guide/module_dev/buddies/cvterm.rst
@@ -64,7 +64,7 @@ insertCv()
 Inserts a new record into the chado `cv <https://laceysanderson.github.io/chado-docs/cv/tables/cv.html>`_ table,
 and returns a ChadoBuddyRecord describing the inserted record.
 
-Usage: ``$chado_buddy_records = $cvterm_instance->insertCv($values, $options);``
+Usage: ``$chado_buddy_record = $cvterm_instance->insertCv($values, $options);``
 
 Valid keys for ``$values``:
 
@@ -84,7 +84,7 @@ updateCv()
 Updates an existing record in the chado `cv <https://laceysanderson.github.io/chado-docs/cv/tables/cv.html>`_ table,
 and returns a ChadoBuddyRecord describing the updated record.
 
-Usage: ``$chado_buddy_records = $cvterm_instance->updateCv($values, $conditions, $options);``
+Usage: ``$chado_buddy_record = $cvterm_instance->updateCv($values, $conditions, $options);``
 
 Valid keys for ``$values`` and ``$conditions``:
 
@@ -105,7 +105,7 @@ Updates a record if it exists, or inserts it if it does not, in the chado `cv <h
 and returns a ChadoBuddyRecord describing the updated record.
 Only keys designated with a Ⓠ are used for the query to find the record to update if it already exists.
 
-Usage: ``$chado_buddy_records = $cvterm_instance->insertCv($values, $options);``
+Usage: ``$chado_buddy_record = $cvterm_instance->insertCv($values, $options);``
 
 Valid keys for ``$values``:
 
@@ -164,7 +164,7 @@ insertCvterm()
 Inserts a new record into the chado `cvterm <https://laceysanderson.github.io/chado-docs/cv/tables/cvterm.html>`_ table,
 and returns a ChadoBuddyRecord describing the updated record.
 
-Usage: ``$chado_buddy_records = $cvterm_instance->insertCvterm($values, $options);``
+Usage: ``$chado_buddy_record = $cvterm_instance->insertCvterm($values, $options);``
 
 Valid keys for ``$values``:
 
@@ -205,7 +205,7 @@ updateCvterm()
 Updates an existing record in the chado `cvterm <https://laceysanderson.github.io/chado-docs/cv/tables/cvterm.html>`_ table,
 and returns a ChadoBuddyRecord describing the updated record.
 
-Usage: ``$chado_buddy_records = $cvterm_instance->updateCvterm($values, $conditions, $options);``
+Usage: ``$chado_buddy_record = $cvterm_instance->updateCvterm($values, $conditions, $options);``
 
 Valid keys for ``$values`` and ``$conditions``:
 
@@ -248,7 +248,7 @@ Updates a record if it exists, or inserts it if it does not, in the chado `cvter
 and returns a ChadoBuddyRecord describing the updated record.
 Only keys designated with a Ⓠ are used for the query to find the record to update if it already exists.
 
-Usage: ``$chado_buddy_records = $cvterm_instance->insertCvterm($values, $options);``
+Usage: ``$chado_buddy_record = $cvterm_instance->insertCvterm($values, $options);``
 
 Valid keys for ``$values``:
 
@@ -336,7 +336,7 @@ insertCvtermSynonym()
 Inserts a new record into the chado `cvtermsynonym <https://laceysanderson.github.io/chado-docs/cv/tables/cvtermsynonym.html>`_ table,
 and returns a ChadoBuddyRecord describing the inserted record.
 
-Usage: ``$chado_buddy_records = $cvterm_instance->getCvtermSynonym($conditions, $options);``
+Usage: ``$chado_buddy_record = $cvterm_instance->getCvtermSynonym($conditions, $options);``
 
 Valid keys for ``$conditions`` are all of those specified
 for :ref:`insertCvterm()` plus these additional keys:
@@ -357,7 +357,7 @@ updateCvtermSynonym()
 Updates an existing record in the chado `cvtermsynonym <https://laceysanderson.github.io/chado-docs/cv/tables/cvtermsynonym.html>`_ table,
 and returns a ChadoBuddyRecord describing the updated record.
 
-Usage: ``$chado_buddy_records = $cvterm_instance->getCvtermSynonym($conditions, $options);``
+Usage: ``$chado_buddy_record = $cvterm_instance->getCvtermSynonym($conditions, $options);``
 
 Valid keys for ``$conditions`` are all of those specified
 for :ref:`updateCvterm()` plus these additional keys:
@@ -379,7 +379,7 @@ upsertCvtermSynonym()
 Updates a record if it exists, or inserts it if it does not, in the chado `cvtermsynonym <https://laceysanderson.github.io/chado-docs/cv/tables/cvtermsynonym.html>`_ table,
 and returns a ChadoBuddyRecord describing the updated record.
 
-Usage: ``$chado_buddy_records = $cvterm_instance->getCvtermSynonym($conditions, $options);``
+Usage: ``$chado_buddy_record = $cvterm_instance->getCvtermSynonym($conditions, $options);``
 
 Valid keys for ``$conditions`` are all of those specified
 for :ref:`upsertCvterm()` plus these additional keys:

--- a/docs/dev_guide/module_dev/buddies/cvterm.rst
+++ b/docs/dev_guide/module_dev/buddies/cvterm.rst
@@ -299,10 +299,43 @@ Parameter ChadoBuddyRecord ``$cvterm`` is a ChadoBuddyRecord returned by one of 
 
 Valid keys for ``$options``:
 
-* ``pkey`` Looking up the primary key for the base table is costly. If it is
+* ``pkey`` - Looking up the primary key for the base table is costly. If it is
   known, then pass it in as this option for better performance.
 * Also pass in any other columns used in the linking table. Sometimes there is a NOT NULL
   constraint, so a value is required.
+* ``lookup_columns`` - If you do not pass in any other columns, this option controls
+  whether they will be looked up automatically. By default it is set to TRUE, but this
+  is a slight performance hit. It can be disabled by setting to FALSE, or by including
+  one of the columns below:
+
+
+  .. table:: Chado 1.3 defines these columns in the various linking tables. Only those listed with "not null" are required.:
+
+  +-----------------------------+----------+-------------+-------------+----------------+
+  | table                       | pub_id   | is_not      | rank        | cvterm_type_id |
+  +=============================+==========+=============+=============+================+
+  | analysis_cvterm             | -absent- | has default | has default | -absent-       |
+  +-----------------------------+----------+-------------+-------------+----------------+
+  | cell_line_cvterm            | not null | -absent-    | has default | -absent-       |
+  +-----------------------------+----------+-------------+-------------+----------------+
+  | environment_cvterm          | -absent- | -absent-    | -absent-    | -absent-       |
+  +-----------------------------+----------+-------------+-------------+----------------+
+  | expression_cvterm           | -absent- | -absent-    | has default | not null       |
+  +-----------------------------+----------+-------------+-------------+----------------+
+  | feature_cvterm              | not null | has default | has default | -absent-       |
+  +-----------------------------+----------+-------------+-------------+----------------+
+  | library_cvterm              | not null | -absent-    | -absent-    | -absent-       |
+  +-----------------------------+----------+-------------+-------------+----------------+
+  | organism_cvterm             | not null | -absent-    | has default | -absent-       |
+  +-----------------------------+----------+-------------+-------------+----------------+
+  | phenotype_comparison_cvterm | not null | -absent-    | has default | -absent-       |
+  +-----------------------------+----------+-------------+-------------+----------------+
+  | phenotype_cvterm            | -absent- | -absent-    | has default | -absent-       |
+  +-----------------------------+----------+-------------+-------------+----------------+
+  | stock_cvterm                | not null | has default | has default | -absent-       |
+  +-----------------------------+----------+-------------+-------------+----------------+
+  | stock_relationship_cvterm   | yes null | -absent-    | -absent-    | -absent-       |
+  +-----------------------------+----------+-------------+-------------+----------------+
 
 This function returns TRUE if successful.
 

--- a/docs/dev_guide/module_dev/buddies/dbxref.rst
+++ b/docs/dev_guide/module_dev/buddies/dbxref.rst
@@ -35,7 +35,7 @@ getDb()
 
 Retrieves one or more records from the chado `db <https://laceysanderson.github.io/chado-docs/db/tables/db.html>`_ table.
 
-Usage: ``$chado_buddy_records = $instance->getDb($conditions, $options);``
+Usage: ``$chado_buddy_records = $dbxref_instance->getDb($conditions, $options);``
 
 Valid keys for ``$conditions``:
 
@@ -48,6 +48,11 @@ Valid keys for ``$conditions``:
 Valid settings for ``$options``:
 
 * ``'case_insensitive' => key`` or ``'case_insensitive' => [key1, key2, ...]``
+  Any keys specified here will be queried without case sensitivity. For example
+
+  ``$dbxref_instance->getDb(['db.name' => 'edam'], ['case_insensitive' => 'db.name']);``
+
+  will return either 'edam' or 'EDAM' or both.
 
 
 
@@ -56,7 +61,7 @@ insertDb()
 
 Inserts a new record into the chado `db <https://laceysanderson.github.io/chado-docs/db/tables/db.html>`_ table.
 
-Usage: ``$chado_buddy_records = $instance->insertDb($values, $options);``
+Usage: ``$chado_buddy_records = $dbxref_instance->insertDb($values, $options);``
 
 Valid keys for ``$values``:
 
@@ -76,7 +81,7 @@ updateDb()
 
 Updates an existing record in the chado `db <https://laceysanderson.github.io/chado-docs/db/tables/db.html>`_ table.
 
-Usage: ``$chado_buddy_records = $instance->updateDb($values, $conditions, $options);``
+Usage: ``$chado_buddy_records = $dbxref_instance->updateDb($values, $conditions, $options);``
 
 Valid keys for ``$values`` and ``$conditions``:
 
@@ -85,7 +90,7 @@ Valid keys for ``$values`` and ``$conditions``:
 * ``db.url``
 * ``db.urlprefix``
 
-Valid keys for ``$values`` only:
+Valid keys for ``$conditions`` only:
 
 * ``db.db_id``
 
@@ -95,9 +100,9 @@ upsertDb()
 ^^^^^^^^^^^^
 
 Updates a record if it exists, or inserts it if it does not, in the chado `db <https://laceysanderson.github.io/chado-docs/db/tables/db.html>`_ table.
-Only keys designated with a Ⓠ are used to find the record to update if it already exists.
+Only keys designated with a Ⓠ are used for the query to find the record to update if it already exists.
 
-Usage: ``$chado_buddy_records = $instance->insertDb($values, $options);``
+Usage: ``$chado_buddy_records = $dbxref_instance->insertDb($values, $options);``
 
 Valid keys for ``$values``:
 
@@ -117,7 +122,7 @@ getDbxref()
 
 Retrieves one or more records from the chado `dbxref <https://laceysanderson.github.io/chado-docs/db/tables/dbxref.html>`_ table.
 
-Usage: ``$chado_buddy_records = $instance->getDbxref($conditions, $options);``
+Usage: ``$chado_buddy_records = $dbxref_instance->getDbxref($conditions, $options);``
 
 Valid keys for ``$conditions``:
 
@@ -135,6 +140,7 @@ Valid keys for ``$conditions``:
 Valid settings for ``$options``:
 
 * ``'case_insensitive' => key`` or ``'case_insensitive' => [key1, key2, ...]``
+  Any keys specified here will be queried without case sensitivity, e.g. 'edam' == 'EDAM'
 
 
 
@@ -143,7 +149,7 @@ insertDbxref()
 
 Inserts a new record into the chado `dbxref <https://laceysanderson.github.io/chado-docs/db/tables/dbxref.html>`_ table.
 
-Usage: ``$chado_buddy_records = $instance->insertDbxref($values, $options);``
+Usage: ``$chado_buddy_records = $dbxref_instance->insertDbxref($values, $options);``
 
 Valid keys for ``$values``:
 
@@ -169,7 +175,7 @@ updateDbxref()
 
 Updates an existing record in the chado `dbxref <https://laceysanderson.github.io/chado-docs/db/tables/dbxref.html>`_ table.
 
-Usage: ``$chado_buddy_records = $instance->updateDbxref($values, $conditions, $options);``
+Usage: ``$chado_buddy_records = $dbxref_instance->updateDbxref($values, $conditions, $options);``
 
 Valid keys for ``$values`` and ``$conditions``:
 
@@ -178,7 +184,7 @@ Valid keys for ``$values`` and ``$conditions``:
 * ``dbxref.accession``
 * ``dbxref.version``
 
-Valid keys for ``$values`` only:
+Valid keys for ``$conditions`` only:
 
 * ``db.db_id``
 * ``db.name``
@@ -192,9 +198,9 @@ upsertDbxref()
 ^^^^^^^^^^^^^^^^
 
 Updates a record if it exists, or inserts it if it does not, in the chado `dbxref <https://laceysanderson.github.io/chado-docs/db/tables/dbxref.html>`_ table.
-Only keys designated with a Ⓠ are used to find the record to update if it already exists.
+Only keys designated with a Ⓠ are used for the query to find the record to update if it already exists.
 
-Usage: ``$chado_buddy_records = $instance->insertDbxref($values, $options);``
+Usage: ``$chado_buddy_records = $dbxref_instance->insertDbxref($values, $options);``
 
 Valid keys for ``$values``:
 
@@ -220,7 +226,7 @@ associateDbxref()
 Given an existing dbxref record, associate it with a record in a chado table using its linking table.
 Both the dbxref and the chado record indicated by $record_id must already exist.
 
-Usage: ``$boolean_result = $instance->associateDbxref($base_table, $record_id, $dbxref, $options);``
+Usage: ``$boolean_result = $dbxref_instance->associateDbxref($base_table, $record_id, $dbxref, $options);``
 
 Parameter string ``$base_table`` is the base table for which the dbxref should be associated.
 For example, to associate a dbxref with a feature the base_table=``feature`` and dbxref_id is added to the
@@ -252,7 +258,7 @@ urlprefix. But Tripal supports the use of {db} and {accession} tokens
 in the db.urlprefix string. If present, they will be replaced with the
 db name and dbxref accession, respectively.
 
-Usage: ``$url_string = $instance->getDbxrefUrl($dbxref, $options);``
+Usage: ``$url_string = $dbxref_instance->getDbxrefUrl($dbxref, $options);``
 
 Parameter ChadoBuddyRecord ``$dbxref`` is a record returned by one of the ``xxxDbxref()`` or ``xxxCvterm()`` functions.
 

--- a/docs/dev_guide/module_dev/buddies/dbxref.rst
+++ b/docs/dev_guide/module_dev/buddies/dbxref.rst
@@ -34,7 +34,8 @@ This buddy provides the following functions:
 getDb()
 ^^^^^^^^^
 
-Retrieves one or more records from the chado `db <https://laceysanderson.github.io/chado-docs/db/tables/db.html>`_ table.
+Retrieves zero or more records from the chado `db <https://laceysanderson.github.io/chado-docs/db/tables/db.html>`_ table,
+and returns an array of ChadoBuddyRecord records.
 
 Usage: ``$chado_buddy_records = $dbxref_instance->getDb($conditions, $options);``
 
@@ -61,7 +62,8 @@ Valid settings for ``$options``:
 insertDb()
 ^^^^^^^^^^^^
 
-Inserts a new record into the chado `db <https://laceysanderson.github.io/chado-docs/db/tables/db.html>`_ table.
+Inserts a new record into the chado `db <https://laceysanderson.github.io/chado-docs/db/tables/db.html>`_ table,
+and returns a ChadoBuddyRecord describing the inserted record.
 
 Usage: ``$chado_buddy_records = $dbxref_instance->insertDb($values, $options);``
 
@@ -82,7 +84,8 @@ Required keys to insert a new record:
 updateDb()
 ^^^^^^^^^^^^
 
-Updates an existing record in the chado `db <https://laceysanderson.github.io/chado-docs/db/tables/db.html>`_ table.
+Updates an existing record in the chado `db <https://laceysanderson.github.io/chado-docs/db/tables/db.html>`_ table,
+and returns a ChadoBuddyRecord describing the updated record.
 
 Usage: ``$chado_buddy_records = $dbxref_instance->updateDb($values, $conditions, $options);``
 
@@ -103,7 +106,8 @@ Valid keys for ``$conditions`` only:
 upsertDb()
 ^^^^^^^^^^^^
 
-Updates a record if it exists, or inserts it if it does not, in the chado `db <https://laceysanderson.github.io/chado-docs/db/tables/db.html>`_ table.
+Updates a record if it exists, or inserts it if it does not, in the chado `db <https://laceysanderson.github.io/chado-docs/db/tables/db.html>`_ table,
+and returns a ChadoBuddyRecord describing the updated record.
 Only keys designated with a Ⓠ are used for the query to find the record to update if it already exists.
 
 Usage: ``$chado_buddy_records = $dbxref_instance->insertDb($values, $options);``
@@ -125,7 +129,8 @@ Required keys to upsert a new record:
 getDbxref()
 ^^^^^^^^^^^^^
 
-Retrieves one or more records from the chado `dbxref <https://laceysanderson.github.io/chado-docs/db/tables/dbxref.html>`_ table.
+Retrieves zero or more records from the chado `dbxref <https://laceysanderson.github.io/chado-docs/db/tables/dbxref.html>`_ table,
+and returns an array of ChadoBuddyRecord records.
 
 Usage: ``$chado_buddy_records = $dbxref_instance->getDbxref($conditions, $options);``
 
@@ -153,7 +158,8 @@ Valid settings for ``$options``:
 insertDbxref()
 ^^^^^^^^^^^^^^^^
 
-Inserts a new record into the chado `dbxref <https://laceysanderson.github.io/chado-docs/db/tables/dbxref.html>`_ table.
+Inserts a new record into the chado `dbxref <https://laceysanderson.github.io/chado-docs/db/tables/dbxref.html>`_ table,
+and returns a ChadoBuddyRecord describing the inserted record.
 
 Usage: ``$chado_buddy_records = $dbxref_instance->insertDbxref($values, $options);``
 
@@ -180,7 +186,8 @@ Required keys to insert a new record:
 updateDbxref()
 ^^^^^^^^^^^^^^^^
 
-Updates an existing record in the chado `dbxref <https://laceysanderson.github.io/chado-docs/db/tables/dbxref.html>`_ table.
+Updates an existing record in the chado `dbxref <https://laceysanderson.github.io/chado-docs/db/tables/dbxref.html>`_ table,
+and returns a ChadoBuddyRecord describing the updated record.
 
 Usage: ``$chado_buddy_records = $dbxref_instance->updateDbxref($values, $conditions, $options);``
 
@@ -206,7 +213,8 @@ Valid keys for ``$conditions`` only:
 upsertDbxref()
 ^^^^^^^^^^^^^^^^
 
-Updates a record if it exists, or inserts it if it does not, in the chado `dbxref <https://laceysanderson.github.io/chado-docs/db/tables/dbxref.html>`_ table.
+Updates a record if it exists, or inserts it if it does not, in the chado `dbxref <https://laceysanderson.github.io/chado-docs/db/tables/dbxref.html>`_ table,
+and returns a ChadoBuddyRecord describing the updated record.
 Only keys designated with a Ⓠ are used for the query to find the record to update if it already exists.
 
 Usage: ``$chado_buddy_records = $dbxref_instance->insertDbxref($values, $options);``

--- a/docs/dev_guide/module_dev/buddies/dbxref.rst
+++ b/docs/dev_guide/module_dev/buddies/dbxref.rst
@@ -65,7 +65,7 @@ insertDb()
 Inserts a new record into the chado `db <https://laceysanderson.github.io/chado-docs/db/tables/db.html>`_ table,
 and returns a ChadoBuddyRecord describing the inserted record.
 
-Usage: ``$chado_buddy_records = $dbxref_instance->insertDb($values, $options);``
+Usage: ``$chado_buddy_record = $dbxref_instance->insertDb($values, $options);``
 
 Valid keys for ``$values``:
 
@@ -87,7 +87,7 @@ updateDb()
 Updates an existing record in the chado `db <https://laceysanderson.github.io/chado-docs/db/tables/db.html>`_ table,
 and returns a ChadoBuddyRecord describing the updated record.
 
-Usage: ``$chado_buddy_records = $dbxref_instance->updateDb($values, $conditions, $options);``
+Usage: ``$chado_buddy_record = $dbxref_instance->updateDb($values, $conditions, $options);``
 
 Valid keys for ``$values`` and ``$conditions``:
 
@@ -110,7 +110,7 @@ Updates a record if it exists, or inserts it if it does not, in the chado `db <h
 and returns a ChadoBuddyRecord describing the updated record.
 Only keys designated with a Ⓠ are used for the query to find the record to update if it already exists.
 
-Usage: ``$chado_buddy_records = $dbxref_instance->insertDb($values, $options);``
+Usage: ``$chado_buddy_record = $dbxref_instance->insertDb($values, $options);``
 
 Valid keys for ``$values``:
 
@@ -161,7 +161,7 @@ insertDbxref()
 Inserts a new record into the chado `dbxref <https://laceysanderson.github.io/chado-docs/db/tables/dbxref.html>`_ table,
 and returns a ChadoBuddyRecord describing the inserted record.
 
-Usage: ``$chado_buddy_records = $dbxref_instance->insertDbxref($values, $options);``
+Usage: ``$chado_buddy_record = $dbxref_instance->insertDbxref($values, $options);``
 
 Valid keys for ``$values``:
 
@@ -189,7 +189,7 @@ updateDbxref()
 Updates an existing record in the chado `dbxref <https://laceysanderson.github.io/chado-docs/db/tables/dbxref.html>`_ table,
 and returns a ChadoBuddyRecord describing the updated record.
 
-Usage: ``$chado_buddy_records = $dbxref_instance->updateDbxref($values, $conditions, $options);``
+Usage: ``$chado_buddy_record = $dbxref_instance->updateDbxref($values, $conditions, $options);``
 
 Valid keys for ``$values`` and ``$conditions``:
 
@@ -217,7 +217,7 @@ Updates a record if it exists, or inserts it if it does not, in the chado `dbxre
 and returns a ChadoBuddyRecord describing the updated record.
 Only keys designated with a Ⓠ are used for the query to find the record to update if it already exists.
 
-Usage: ``$chado_buddy_records = $dbxref_instance->insertDbxref($values, $options);``
+Usage: ``$chado_buddy_record = $dbxref_instance->insertDbxref($values, $options);``
 
 Valid keys for ``$values``:
 

--- a/docs/dev_guide/module_dev/buddies/dbxref.rst
+++ b/docs/dev_guide/module_dev/buddies/dbxref.rst
@@ -2,70 +2,262 @@
 Chado Dbxref Buddy
 ====================
 
-This buddy has the instance name ``chado_dbxref_buddy`` and the class name ``ChadoDbxrefBuddy``.
+This buddy has the class name ``ChadoDbxrefBuddy`` and the instance name ``chado_dbxref_buddy``.
 
 This is the simplest buddy since it handles just two chado tables,
 the ``db`` and ``dbxref`` tables.
 
-It provides nine functions:
+It provides the following functions:
 
   .. table:: Chado Dbxref Buddy:
 
-    +------------------+--------------+----------------+
-    | Function         | db table     | dbxref table   |
-    +==================+==============+================+
-    | Lookup           | :ref:`getDb()` | getDbxref()    |
-    +------------------+--------------+----------------+
-    | Insert           | insertDb()   | insertDbxref() |
-    +------------------+--------------+----------------+
-    | Update           | updateDb()   | updateDbxref() |
-    +------------------+--------------+----------------+
-    | Upsert           | upsertDb()   | upsertDbxref() |
-    +------------------+--------------+----------------+
-    | Associate        |              | getDbxref()    |
-    +------------------+--------------+----------------+
-    | Helper           |              | getDbxrefUrl() |
-    +------------------+--------------+----------------+
+    +------------------+-------------------+--------------------------+
+    | Type of          |                   |                          |
+    | Function         | db table          | dbxref table             |
+    +==================+===================+==========================+
+    | Lookup           | :ref:`getDb()`    | :ref:`getDbxref()`       |
+    +------------------+-------------------+--------------------------+
+    | Insert           | :ref:`insertDb()` | :ref:`insertDbxref()`    |
+    +------------------+-------------------+--------------------------+
+    | Update           | :ref:`updateDb()` | :ref:`updateDbxref()`    |
+    +------------------+-------------------+--------------------------+
+    | Upsert           | :ref:`upsertDb()` | :ref:`upsertDbxref()`    |
+    +------------------+-------------------+--------------------------+
+    | Associate        |                   | :ref:`associateDbxref()` |
+    +------------------+-------------------+--------------------------+
+    | Helper           |                   | :ref:`getDbxrefUrl()`    |
+    +------------------+-------------------+--------------------------+
 
 
 
-getDb
-^^^^^^^
+getDb()
+^^^^^^^^^
 
-Retrieves records from the chado ``db`` table.
+Retrieves one or more records from the chado `db <https://laceysanderson.github.io/chado-docs/db/tables/db.html>`_ table.
 
-Usage: ``$records = $instance->getDb($conditions, $options);``
+Usage: ``$chado_buddy_records = $instance->getDb($conditions, $options);``
 
-Valid keys for $conditions:
+Valid keys for ``$conditions``:
 
-* db.db_id
-* db.name
-* db.description
-* db.url
-* db.urlprefix
+* ``db.db_id``
+* ``db.name``
+* ``db.description``
+* ``db.url``
+* ``db.urlprefix``
 
-Valid settings for $options:
+Valid settings for ``$options``:
 
-  'case_insensitive' => key
-  'case_insensitive' => [key1, key2];
-
+* ``'case_insensitive' => key`` or ``'case_insensitive' => [key1, key2, ...]``
 
 
-insertDb
-^^^^^^^^^^
 
-Inserts a new record into the chado ``db`` table.
+insertDb()
+^^^^^^^^^^^^
 
-Usage: ``$records = $instance->insertDb($values, $options);``
+Inserts a new record into the chado `db <https://laceysanderson.github.io/chado-docs/db/tables/db.html>`_ table.
 
-Valid keys for $conditions:
+Usage: ``$chado_buddy_records = $instance->insertDb($values, $options);``
 
-* db.name
-* db.description
-* db.url
-* db.urlprefix
+Valid keys for ``$values``:
+
+* ``db.name``
+* ``db.description``
+* ``db.url``
+* ``db.urlprefix``
 
 Required keys to insert a new record:
 
-* db.name
+* ``db.name``
 
+
+
+updateDb()
+^^^^^^^^^^^^
+
+Updates an existing record in the chado `db <https://laceysanderson.github.io/chado-docs/db/tables/db.html>`_ table.
+
+Usage: ``$chado_buddy_records = $instance->updateDb($values, $conditions, $options);``
+
+Valid keys for ``$values`` and ``$conditions``:
+
+* ``db.name``
+* ``db.description``
+* ``db.url``
+* ``db.urlprefix``
+
+Valid keys for ``$values`` only:
+
+* ``db.db_id``
+
+
+
+upsertDb()
+^^^^^^^^^^^^
+
+Updates a record if it exists, or inserts it if it does not, in the chado `db <https://laceysanderson.github.io/chado-docs/db/tables/db.html>`_ table.
+Only keys designated with a Ⓠ are used to find the record to update if it already exists.
+
+Usage: ``$chado_buddy_records = $instance->insertDb($values, $options);``
+
+Valid keys for ``$values``:
+
+* ``db.name`` Ⓠ
+* ``db.description``
+* ``db.url``
+* ``db.urlprefix``
+
+Required keys to upsert a new record:
+
+* ``db.name``
+
+
+
+getDbxref()
+^^^^^^^^^^^^^
+
+Retrieves one or more records from the chado `dbxref <https://laceysanderson.github.io/chado-docs/db/tables/dbxref.html>`_ table.
+
+Usage: ``$chado_buddy_records = $instance->getDbxref($conditions, $options);``
+
+Valid keys for ``$conditions``:
+
+* ``db.db_id``
+* ``db.name``
+* ``db.description``
+* ``db.url``
+* ``db.urlprefix``
+* ``dbxref.dbxref_id``
+* ``dbxref.db_id``
+* ``dbxref.description``
+* ``dbxref.accession``
+* ``dbxref.version``
+
+Valid settings for ``$options``:
+
+* ``'case_insensitive' => key`` or ``'case_insensitive' => [key1, key2, ...]``
+
+
+
+insertDbxref()
+^^^^^^^^^^^^^^^^
+
+Inserts a new record into the chado `dbxref <https://laceysanderson.github.io/chado-docs/db/tables/dbxref.html>`_ table.
+
+Usage: ``$chado_buddy_records = $instance->insertDbxref($values, $options);``
+
+Valid keys for ``$values``:
+
+* ``db.name``
+* ``db.description``
+* ``db.url``
+* ``db.urlprefix``
+* ``dbxref.dbxref_id``
+* ``dbxref.db_id``
+* ``dbxref.description``
+* ``dbxref.accession``
+* ``dbxref.version``
+
+Required keys to insert a new record:
+
+* either ``db.db_id`` or ``dbxref.db_id`` or ``db.name``
+* ``dbxref.accession``
+
+
+
+updateDbxref()
+^^^^^^^^^^^^^^^^
+
+Updates an existing record in the chado `dbxref <https://laceysanderson.github.io/chado-docs/db/tables/dbxref.html>`_ table.
+
+Usage: ``$chado_buddy_records = $instance->updateDbxref($values, $conditions, $options);``
+
+Valid keys for ``$values`` and ``$conditions``:
+
+* ``dbxref.db_id``
+* ``dbxref.description``
+* ``dbxref.accession``
+* ``dbxref.version``
+
+Valid keys for ``$values`` only:
+
+* ``db.db_id``
+* ``db.name``
+* ``db.description``
+* ``db.url``
+* ``db.urlprefix``
+* ``dbxref.dbxref_id``
+
+
+upsertDbxref()
+^^^^^^^^^^^^^^^^
+
+Updates a record if it exists, or inserts it if it does not, in the chado `dbxref <https://laceysanderson.github.io/chado-docs/db/tables/dbxref.html>`_ table.
+Only keys designated with a Ⓠ are used to find the record to update if it already exists.
+
+Usage: ``$chado_buddy_records = $instance->insertDbxref($values, $options);``
+
+Valid keys for ``$values``:
+
+* ``db.name`` Ⓠ
+* ``db.description``
+* ``db.url``
+* ``db.urlprefix``
+* ``dbxref.db_id`` Ⓠ
+* ``dbxref.description``
+* ``dbxref.accession`` Ⓠ
+* ``dbxref.version`` Ⓠ
+
+Required keys to upsert a new record:
+
+* either ``db.db_id`` or ``dbxref.db_id`` or ``db.name``
+* ``dbxref.accession``
+
+
+
+associateDbxref()
+^^^^^^^^^^^^^^^^^^^
+
+Given an existing dbxref record, associate it with a record in a chado table using its linking table.
+Both the dbxref and the chado record indicated by $record_id must already exist.
+
+Usage: ``$boolean_result = $instance->associateDbxref($base_table, $record_id, $dbxref, $options);``
+
+Parameter string ``$base_table`` is the base table for which the dbxref should be associated.
+For example, to associate a dbxref with a feature the base_table=``feature`` and dbxref_id is added to the
+``feature_dbxref`` table.
+
+Parameter integer ``$record_id`` is the primary key of the base_table to associate the dbxref with.
+
+Parameter ChadoBuddyRecord ``$dbxref`` is a record returned by one of the ``xxxDbxref()`` or ``xxxCvterm()`` functions.
+
+Valid keys for ``$options``:
+
+* ``pkey`` Looking up the primary key for the base table is costly. If it is
+  known, then pass it in as this option for better performance.
+* Also pass in any other columns used in the linking table. Sometimes there is a NOT NULL
+  constraint, so a value is required.
+
+This function returns TRUE if successful.
+
+
+
+getDbxrefUrl()
+^^^^^^^^^^^^^^^^
+
+Generates a URL for a database reference (e.g. the reference for a cvterm).
+If the URL prefix is provided for the database record of a cvterm,
+then a URL can be created for the term. By default, the db name and
+dbxref accession are concatenated and appended to the end of the
+urlprefix. But Tripal supports the use of {db} and {accession} tokens
+in the db.urlprefix string. If present, they will be replaced with the
+db name and dbxref accession, respectively.
+
+Usage: ``$url_string = $instance->getDbxrefUrl($dbxref, $options);``
+
+Parameter ChadoBuddyRecord ``$dbxref`` is a record returned by one of the ``xxxDbxref()`` or ``xxxCvterm()`` functions.
+
+Valid keys for ``$options``:
+
+* None, here for consistency.
+
+Returns a string containing the URL as described above.

--- a/docs/dev_guide/module_dev/buddies/dbxref.rst
+++ b/docs/dev_guide/module_dev/buddies/dbxref.rst
@@ -7,7 +7,7 @@ This buddy has the class name ``ChadoDbxrefBuddy`` and the instance name ``chado
 This is the simplest buddy since it handles just two chado tables,
 the ``db`` and ``dbxref`` tables.
 
-It provides the following functions:
+This buddy provides the following functions:
 
   .. table:: Chado Dbxref Buddy:
 
@@ -44,6 +44,7 @@ Valid keys for ``$conditions``:
 * ``db.description``
 * ``db.url``
 * ``db.urlprefix``
+* ``buddy_record``
 
 Valid settings for ``$options``:
 
@@ -69,6 +70,7 @@ Valid keys for ``$values``:
 * ``db.description``
 * ``db.url``
 * ``db.urlprefix``
+* ``buddy_record``
 
 Required keys to insert a new record:
 
@@ -89,6 +91,7 @@ Valid keys for ``$values`` and ``$conditions``:
 * ``db.description``
 * ``db.url``
 * ``db.urlprefix``
+* ``buddy_record``
 
 Valid keys for ``$conditions`` only:
 
@@ -110,6 +113,7 @@ Valid keys for ``$values``:
 * ``db.description``
 * ``db.url``
 * ``db.urlprefix``
+* ``buddy_record``
 
 Required keys to upsert a new record:
 
@@ -136,6 +140,7 @@ Valid keys for ``$conditions``:
 * ``dbxref.description``
 * ``dbxref.accession``
 * ``dbxref.version``
+* ``buddy_record``
 
 Valid settings for ``$options``:
 
@@ -162,6 +167,7 @@ Valid keys for ``$values``:
 * ``dbxref.description``
 * ``dbxref.accession``
 * ``dbxref.version``
+* ``buddy_record``
 
 Required keys to insert a new record:
 
@@ -183,6 +189,7 @@ Valid keys for ``$values`` and ``$conditions``:
 * ``dbxref.description``
 * ``dbxref.accession``
 * ``dbxref.version``
+* ``buddy_record``
 
 Valid keys for ``$conditions`` only:
 
@@ -212,6 +219,7 @@ Valid keys for ``$values``:
 * ``dbxref.description``
 * ``dbxref.accession`` Ⓠ
 * ``dbxref.version`` Ⓠ
+* ``buddy_record``
 
 Required keys to upsert a new record:
 

--- a/docs/dev_guide/module_dev/buddies/dbxref.rst
+++ b/docs/dev_guide/module_dev/buddies/dbxref.rst
@@ -4,8 +4,9 @@ Chado Dbxref Buddy
 
 This buddy has the class name ``ChadoDbxrefBuddy`` and the instance name ``chado_dbxref_buddy``.
 
-This is the simplest buddy since it handles just two chado tables,
-the ``db`` and ``dbxref`` tables.
+This is the simplest buddy since it handles just two chado tables, the
+`db <https://laceysanderson.github.io/chado-docs/db/tables/db.html>`_
+and `dbxref <https://laceysanderson.github.io/chado-docs/db/tables/dbxref.html>`_ tables.
 
 This buddy provides the following functions:
 
@@ -199,6 +200,7 @@ Valid keys for ``$conditions`` only:
 * ``db.url``
 * ``db.urlprefix``
 * ``dbxref.dbxref_id``
+
 
 
 upsertDbxref()

--- a/docs/dev_guide/module_dev/buddies/dbxref.rst
+++ b/docs/dev_guide/module_dev/buddies/dbxref.rst
@@ -1,0 +1,71 @@
+
+Chado Dbxref Buddy
+====================
+
+This buddy has the instance name ``chado_dbxref_buddy`` and the class name ``ChadoDbxrefBuddy``.
+
+This is the simplest buddy since it handles just two chado tables,
+the ``db`` and ``dbxref`` tables.
+
+It provides nine functions:
+
+  .. table:: Chado Dbxref Buddy:
+
+    +------------------+--------------+----------------+
+    | Function         | db table     | dbxref table   |
+    +==================+==============+================+
+    | Lookup           | :ref:`getDb()` | getDbxref()    |
+    +------------------+--------------+----------------+
+    | Insert           | insertDb()   | insertDbxref() |
+    +------------------+--------------+----------------+
+    | Update           | updateDb()   | updateDbxref() |
+    +------------------+--------------+----------------+
+    | Upsert           | upsertDb()   | upsertDbxref() |
+    +------------------+--------------+----------------+
+    | Associate        |              | getDbxref()    |
+    +------------------+--------------+----------------+
+    | Helper           |              | getDbxrefUrl() |
+    +------------------+--------------+----------------+
+
+
+
+getDb
+^^^^^^^
+
+Retrieves records from the chado ``db`` table.
+
+Usage: ``$records = $instance->getDb($conditions, $options);``
+
+Valid keys for $conditions:
+
+* db.db_id
+* db.name
+* db.description
+* db.url
+* db.urlprefix
+
+Valid settings for $options:
+
+  'case_insensitive' => key
+  'case_insensitive' => [key1, key2];
+
+
+
+insertDb
+^^^^^^^^^^
+
+Inserts a new record into the chado ``db`` table.
+
+Usage: ``$records = $instance->insertDb($values, $options);``
+
+Valid keys for $conditions:
+
+* db.name
+* db.description
+* db.url
+* db.urlprefix
+
+Required keys to insert a new record:
+
+* db.name
+

--- a/docs/dev_guide/module_dev/buddies/inject.rst
+++ b/docs/dev_guide/module_dev/buddies/inject.rst
@@ -1,0 +1,100 @@
+Injecting the Buddy Service
+=============================
+
+A typical use case for a Chado Buddy is in an importer.
+Best practice is to inject the buddy service into your importer class.
+Let's see how that is done.
+
+First you will need to include these classes in your importer:
+
+.. code::
+
+  use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+  use Symfony\Component\DependencyInjection\ContainerInterface;
+  use Drupal\tripal_chado\ChadoBuddy\PluginManagers\ChadoBuddyPluginManager;
+
+Then you will need to implement ``ContainerFactoryPluginInterface`` in your class. For example:
+
+.. code::
+
+  abstract class MyImporter extends ChadoImporterBase implements ContainerFactoryPluginInterface {
+
+Next add a class variable to store the buddy service, and whichever buddy instance or instances you will need.
+
+.. code::
+
+  /**
+   * Used to store the buddy service manager
+   */
+  protected object $buddy_manager;
+
+  /**
+   * Used to store the buddy dbxref instance
+   */
+  protected object $dbxref_instance;
+
+  /**
+   * Used to store the buddy cvterm instance
+   */
+  protected object $cvterm_instance;
+
+  /**
+   * Used to store the buddy property instance
+   */
+  protected object $property_instance;
+
+
+You will need to add a ``create()`` function to your class. An example of this, where
+we inject both the chado database and chado buddy:
+
+.. code::
+
+  /**
+   * Implements ContainerFactoryPluginInterface->create().
+   *
+   * We are injecting an additional dependency here beyond what
+   * the ChadoImporterBase class has, i.e. the ChadoBuddyPluginManager.
+   *
+   * Since we have implemented the ContainerFactoryPluginInterface this static function
+   * will be called behind the scenes when a Plugin Manager uses createInstance(). Specifically
+   * this method is used to determine the parameters to pass to the contructor.
+   *
+   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+   * @param array $configuration
+   * @param string $plugin_id
+   * @param mixed $plugin_definition
+   *
+   * @return static
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('tripal_chado.database'),
+      $container->get('tripal_chado.chado_buddy')
+    );
+  }
+
+Next we add a ``__create()`` function, or if you already have one, add similar code to it. For example:
+
+.. code::
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition,
+                              ChadoConnection $connection, ChadoBuddyPluginManager $buddy_manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $connection);
+    $this->buddy_manager = $buddy_manager;
+    $this->dbxref_instance = $this->buddy_manager->createInstance('chado_dbxref_buddy', []);
+    $this->cvterm_instance = $this->buddy_manager->createInstance('chado_cvterm_buddy', []);
+    $this->property_instance = $this->buddy_manager->createInstance('chado_property_buddy', []);
+  }
+
+That's all there is to it! Now whenever you need to call a buddy function the instance(s)
+will be there and initialized! For example:
+
+.. code::
+
+  $chado_buddy_record = $this->cvterm_instance->getCv('cv.name' => 'local');

--- a/docs/dev_guide/module_dev/buddies/inject.rst
+++ b/docs/dev_guide/module_dev/buddies/inject.rst
@@ -76,7 +76,7 @@ we inject both the chado database and chado buddy:
     );
   }
 
-Next we add a ``__create()`` function, or if you already have one, add similar code to it. For example:
+Next we add a ``__construct()`` function, or if you already have one, add similar code to it. For example:
 
 .. code::
 

--- a/docs/dev_guide/module_dev/buddies/inject.rst
+++ b/docs/dev_guide/module_dev/buddies/inject.rst
@@ -97,4 +97,4 @@ will be there and initialized! For example:
 
 .. code::
 
-  $chado_buddy_record = $this->cvterm_instance->getCv('cv.name' => 'local');
+  $chado_buddy_records = $this->cvterm_instance->getCv('cv.name' => 'local');

--- a/docs/dev_guide/module_dev/buddies/property.rst
+++ b/docs/dev_guide/module_dev/buddies/property.rst
@@ -226,9 +226,11 @@ deleteProperty()
 
 Deletes one or more records in the chado linker table.
 
-Usage: ``$chado_buddy_records = $property_instance->getProperty($base_table, $record_id, $conditions, $options);``
+Usage: ``$number_deleted = $property_instance->getProperty($base_table, $record_id, $conditions, $options);``
 
 Use the same parameters as described above for :ref:`getProperty()`
+
+Returns a count of how many properties were actually deleted.
 
 Additional valid key for ``$options``:
 

--- a/docs/dev_guide/module_dev/buddies/property.rst
+++ b/docs/dev_guide/module_dev/buddies/property.rst
@@ -37,7 +37,8 @@ This buddy provides the following functions:
 getProperty()
 ^^^^^^^^^^^^^^^
 
-Retrieves one or more records from the linker table.
+Retrieves zero or more records from the linker table,
+and returns an array of ChadoBuddyRecord records.
 
 Usage: ``$chado_buddy_records = $property_instance->getProperty($base_table, $record_id, $conditions, $options);``
 
@@ -91,7 +92,8 @@ Valid settings for ``$options``:
 insertProperty()
 ^^^^^^^^^^^^^^^^^^
 
-Inserts a new record into the chado linker table.
+Inserts a new record into the chado linker table,
+and returns a ChadoBuddyRecord describing the inserted record.
 
 Usage: ``$chado_buddy_records = $property_instance->insertProperty($base_table, $record_id, $values, $options);``
 
@@ -133,7 +135,8 @@ Required keys to insert a new record:
 updateProperty()
 ^^^^^^^^^^^^^^^^^^
 
-Updates an existing record in the chado linker table.
+Updates an existing record in the chado linker table,
+and returns a ChadoBuddyRecord describing the updated record.
 
 Usage: ``$chado_buddy_records = $property_instance->updateProperty($base_table, $record_id, $values, $conditions, $options);``
 
@@ -178,7 +181,8 @@ Valid keys for ``$options``:
 upsertProperty()
 ^^^^^^^^^^^^^^^^^^
 
-Updates a record if it exists, or inserts it if it does not, in the chado linker table.
+Updates a record if it exists, or inserts it if it does not, in the chado linker table,
+and returns a ChadoBuddyRecord describing the updated record.
 Only keys designated with a Ⓠ are used for the query to find the record to update if it already exists.
 
 Usage: ``$chado_buddy_records = $property_instance->insertProperty($base_table, $record_id, $values, $options);``

--- a/docs/dev_guide/module_dev/buddies/property.rst
+++ b/docs/dev_guide/module_dev/buddies/property.rst
@@ -4,9 +4,13 @@ Chado Property Buddy
 
 This buddy has the class name ``ChadoPropertyBuddy`` and the instance name ``chado_property_buddy``.
 
-This buddy deals with five chado tables,
-the ``db``, ``dbxref``, ``cv``, ``cvterm``, and "linker" tables.
-The linker table by convention is the name of the base table plus ``prop``.
+This buddy deals with five chado tables, the
+`db <https://laceysanderson.github.io/chado-docs/db/tables/db.html>`_,
+`dbxref <https://laceysanderson.github.io/chado-docs/db/tables/dbxref.html>`_,
+`cv <https://laceysanderson.github.io/chado-docs/cv/tables/cv.html>`_,
+`cvterm <https://laceysanderson.github.io/chado-docs/cv/tables/cvterm.html>`_,
+and "linker" tables.
+The linker table by convention is the name of the specified base table plus ``prop``.
 For example, for the ``project`` table it is ``projectprop``.
 
 This buddy provides the following functions:
@@ -19,13 +23,13 @@ This buddy provides the following functions:
     +==================+=========================+
     | Lookup           | :ref:`getProperty()`    |
     +------------------+-------------------------+
-    | Delete           | :ref:`deleteProperty()` |
-    +------------------+-------------------------+
     | Insert           | :ref:`insertProperty()` |
     +------------------+-------------------------+
     | Update           | :ref:`updateProperty()` |
     +------------------+-------------------------+
     | Upsert           | :ref:`upsertProperty()` |
+    +------------------+-------------------------+
+    | Delete           | :ref:`deleteProperty()` |
     +------------------+-------------------------+
 
 
@@ -35,7 +39,7 @@ getProperty()
 
 Retrieves one or more records from the linker table.
 
-Usage: ``$chado_buddy_records = $cvterm_instance->getProperty($base_table, $record_id, $conditions, $options);``
+Usage: ``$chado_buddy_records = $property_instance->getProperty($base_table, $record_id, $conditions, $options);``
 
 Parameter string ``$base_table`` is the base table for which the property should be associated.
 For example, to associate a property with a feature the base_table=``feature`` and property is added to the
@@ -65,9 +69,9 @@ Valid keys for ``$conditions``:
 * ``cvterm.dbxref_id``
 * ``cvterm.is_obsolete``
 * ``cvterm.is_relationshiptype``
-* linker.linker``_id``
-* linker``.type_id``
-* linker``.value``
+* linker.linker ``_id``
+* linker ``.type_id``
+* linker ``.value``
 * (other columns that may be in the linker table)
 * ``buddy_record``
 
@@ -84,23 +88,12 @@ Valid settings for ``$options``:
 
 
 
-deleteProperty()
-^^^^^^^^^^^^^^^^^^
-
-Deletes one or more records in the chado linker table.
-
-Usage: ``$chado_buddy_records = $cvterm_instance->getProperty($base_table, $record_id, $conditions, $options);``
-
-Use the same parameters as described above for :ref:`getProperty()`
-
-
-
 insertProperty()
 ^^^^^^^^^^^^^^^^^^
 
 Inserts a new record into the chado linker table.
 
-Usage: ``$chado_buddy_records = $cvterm_instance->insertProperty($base_table, $record_id, $values, $options);``
+Usage: ``$chado_buddy_records = $property_instance->insertProperty($base_table, $record_id, $values, $options);``
 
 Valid keys for ``$values``:
 
@@ -124,16 +117,16 @@ Valid keys for ``$values``:
 * ``cvterm.dbxref_id``
 * ``cvterm.is_obsolete``
 * ``cvterm.is_relationshiptype``
-* linker.linker``_id``
-* linker``.type_id``
-* linker``.value``
+* linker.linker ``_id``
+* linker ``.type_id``
+* linker ``.value``
 * (other columns that may be in the linker table)
 * ``buddy_record``
 
 Required keys to insert a new record:
 
-* either ``cvterm.cvterm_id`` or linker``.type_id``
-* linker``.value``
+* either ``cvterm.cvterm_id`` or linker ``.type_id``
+* linker ``.value``
 
 
 
@@ -142,7 +135,7 @@ updateProperty()
 
 Updates an existing record in the chado linker table.
 
-Usage: ``$chado_buddy_records = $cvterm_instance->updateProperty($base_table, $record_id, $values, $conditions, $options);``
+Usage: ``$chado_buddy_records = $property_instance->updateProperty($base_table, $record_id, $values, $conditions, $options);``
 
 Valid keys for ``$values`` and ``$conditions``:
 
@@ -155,6 +148,10 @@ Valid keys for ``$values`` and ``$conditions``:
 * ``cvterm.dbxref_id``
 * ``cvterm.is_obsolete``
 * ``cvterm.is_relationshiptype``
+* linker.linker ``_id``
+* linker ``.type_id``
+* linker ``.value``
+* (other columns that may be in the linker table)
 * ``buddy_record``
 
 Valid keys for ``$conditions`` only:
@@ -177,13 +174,14 @@ Valid keys for ``$options``:
    automatically create a dbxref and cvterm if one does not already exist.
 
 
+
 upsertProperty()
 ^^^^^^^^^^^^^^^^^^
 
 Updates a record if it exists, or inserts it if it does not, in the chado linker table.
 Only keys designated with a Ⓠ are used for the query to find the record to update if it already exists.
 
-Usage: ``$chado_buddy_records = $cvterm_instance->insertProperty($base_table, $record_id, $values, $options);``
+Usage: ``$chado_buddy_records = $property_instance->insertProperty($base_table, $record_id, $values, $options);``
 
 Valid keys for ``$values``:
 
@@ -205,6 +203,9 @@ Valid keys for ``$values``:
 * ``cvterm.dbxref_id`` Ⓠ
 * ``cvterm.is_obsolete`` Ⓠ
 * ``cvterm.is_relationshiptype``
+* linker ``.type_id`` Ⓠ
+* linker ``.value``
+* (other columns that may be in the linker table)
 * ``buddy_record``
 
 Required keys to upsert a new record:
@@ -212,4 +213,20 @@ Required keys to upsert a new record:
 * either ``db.db_id`` or ``dbxref.db_id`` or ``db.name``
 * either ``dbxref.dbxref_id`` or ``cvterm.dbxref_id`` or ``dbxref.accession``
 * either ``cv.cv_id`` or ``cvterm.cv_id`` or ``cv.name``
-* ``cvterm.name``
+* ``cvterm.cvterm_id`` or ``cvterm.name``
+
+
+
+deleteProperty()
+^^^^^^^^^^^^^^^^^^
+
+Deletes one or more records in the chado linker table.
+
+Usage: ``$chado_buddy_records = $property_instance->getProperty($base_table, $record_id, $conditions, $options);``
+
+Use the same parameters as described above for :ref:`getProperty()`
+
+Additional valid key for ``$options``:
+
+* ``max_delete`` This by default is ``1``. If more records than this number would
+  be deleted, an exception is thrown. Set to ``-1`` to disable this limit.

--- a/docs/dev_guide/module_dev/buddies/property.rst
+++ b/docs/dev_guide/module_dev/buddies/property.rst
@@ -95,7 +95,7 @@ insertProperty()
 Inserts a new record into the chado linker table,
 and returns a ChadoBuddyRecord describing the inserted record.
 
-Usage: ``$chado_buddy_records = $property_instance->insertProperty($base_table, $record_id, $values, $options);``
+Usage: ``$chado_buddy_record = $property_instance->insertProperty($base_table, $record_id, $values, $options);``
 
 Valid keys for ``$values``:
 
@@ -138,7 +138,7 @@ updateProperty()
 Updates an existing record in the chado linker table,
 and returns a ChadoBuddyRecord describing the updated record.
 
-Usage: ``$chado_buddy_records = $property_instance->updateProperty($base_table, $record_id, $values, $conditions, $options);``
+Usage: ``$chado_buddy_record = $property_instance->updateProperty($base_table, $record_id, $values, $conditions, $options);``
 
 Valid keys for ``$values`` and ``$conditions``:
 
@@ -185,7 +185,7 @@ Updates a record if it exists, or inserts it if it does not, in the chado linker
 and returns a ChadoBuddyRecord describing the updated record.
 Only keys designated with a Ⓠ are used for the query to find the record to update if it already exists.
 
-Usage: ``$chado_buddy_records = $property_instance->insertProperty($base_table, $record_id, $values, $options);``
+Usage: ``$chado_buddy_record = $property_instance->insertProperty($base_table, $record_id, $values, $options);``
 
 Valid keys for ``$values``:
 
@@ -232,5 +232,5 @@ Use the same parameters as described above for :ref:`getProperty()`
 
 Additional valid key for ``$options``:
 
-* ``max_delete`` This by default is ``1``. If more records than this number would
+* ``max_delete`` - This by default is ``1``. If more records than this number would
   be deleted, an exception is thrown. Set to ``-1`` to disable this limit.

--- a/docs/dev_guide/module_dev/buddies/property.rst
+++ b/docs/dev_guide/module_dev/buddies/property.rst
@@ -1,0 +1,215 @@
+
+Chado Property Buddy
+======================
+
+This buddy has the class name ``ChadoPropertyBuddy`` and the instance name ``chado_property_buddy``.
+
+This buddy deals with five chado tables,
+the ``db``, ``dbxref``, ``cv``, ``cvterm``, and "linker" tables.
+The linker table by convention is the name of the base table plus ``prop``.
+For example, for the ``project`` table it is ``projectprop``.
+
+This buddy provides the following functions:
+
+  .. table:: Chado Cvterm Buddy:
+
+    +------------------+-------------------------+
+    | Type of          |                         |
+    | Function         | "linker" table          |
+    +==================+=========================+
+    | Lookup           | :ref:`getProperty()`    |
+    +------------------+-------------------------+
+    | Delete           | :ref:`deleteProperty()` |
+    +------------------+-------------------------+
+    | Insert           | :ref:`insertProperty()` |
+    +------------------+-------------------------+
+    | Update           | :ref:`updateProperty()` |
+    +------------------+-------------------------+
+    | Upsert           | :ref:`upsertProperty()` |
+    +------------------+-------------------------+
+
+
+
+getProperty()
+^^^^^^^^^^^^^^^
+
+Retrieves one or more records from the linker table.
+
+Usage: ``$chado_buddy_records = $cvterm_instance->getProperty($base_table, $record_id, $conditions, $options);``
+
+Parameter string ``$base_table`` is the base table for which the property should be associated.
+For example, to associate a property with a feature the base_table=``feature`` and property is added to the
+``featureprop`` table.
+
+Parameter integer ``$record_id`` is the primary key of the base_table to associate the dbxref with.
+
+Valid keys for ``$conditions``:
+
+* ``db.db_id``
+* ``db.name``
+* ``db.description``
+* ``db.url``
+* ``db.urlprefix``
+* ``dbxref.dbxref_id``
+* ``dbxref.db_id``
+* ``dbxref.description``
+* ``dbxref.accession``
+* ``dbxref.version``
+* ``cv.cv_id``
+* ``cv.name``
+* ``cv.definition``
+* ``cvterm.cvterm_id``
+* ``cvterm.cv_id``
+* ``cvterm.name``
+* ``cvterm.definition``
+* ``cvterm.dbxref_id``
+* ``cvterm.is_obsolete``
+* ``cvterm.is_relationshiptype``
+* linker.linker``_id``
+* linker``.type_id``
+* linker``.value``
+* (other columns that may be in the linker table)
+* ``buddy_record``
+
+Valid settings for ``$options``:
+
+* ``property_table`` the name of the chado property table, if the default needs to be changed.
+  Normally this is $base_table . 'prop'.
+* ``pkey`` the name of the primary key for the property table, if the default needs to be changed.
+  Normally this is $base_table . '_id'.
+* ``fkey`` the name of the foreign key for the property table, if the default needs to be changed.
+  Normally this is property_table . '_id'.
+* ``'case_insensitive' => key`` or ``'case_insensitive' => [key1, key2, ...]``
+  Any keys specified here will be queried without case sensitivity, e.g. 'edam' == 'EDAM'
+
+
+
+deleteProperty()
+^^^^^^^^^^^^^^^^^^
+
+Deletes one or more records in the chado linker table.
+
+Usage: ``$chado_buddy_records = $cvterm_instance->getProperty($base_table, $record_id, $conditions, $options);``
+
+Use the same parameters as described above for :ref:`getProperty()`
+
+
+
+insertProperty()
+^^^^^^^^^^^^^^^^^^
+
+Inserts a new record into the chado linker table.
+
+Usage: ``$chado_buddy_records = $cvterm_instance->insertProperty($base_table, $record_id, $values, $options);``
+
+Valid keys for ``$values``:
+
+* ``db.db_id``
+* ``db.name``
+* ``db.description``
+* ``db.url``
+* ``db.urlprefix``
+* ``dbxref.dbxref_id``
+* ``dbxref.db_id``
+* ``dbxref.description``
+* ``dbxref.accession``
+* ``dbxref.version``
+* ``cv.cv_id``
+* ``cv.name``
+* ``cv.definition``
+* ``cvterm.cvterm_id``
+* ``cvterm.cv_id``
+* ``cvterm.name``
+* ``cvterm.definition``
+* ``cvterm.dbxref_id``
+* ``cvterm.is_obsolete``
+* ``cvterm.is_relationshiptype``
+* linker.linker``_id``
+* linker``.type_id``
+* linker``.value``
+* (other columns that may be in the linker table)
+* ``buddy_record``
+
+Required keys to insert a new record:
+
+* either ``cvterm.cvterm_id`` or linker``.type_id``
+* linker``.value``
+
+
+
+updateProperty()
+^^^^^^^^^^^^^^^^^^
+
+Updates an existing record in the chado linker table.
+
+Usage: ``$chado_buddy_records = $cvterm_instance->updateProperty($base_table, $record_id, $values, $conditions, $options);``
+
+Valid keys for ``$values`` and ``$conditions``:
+
+* ``dbxref.description``
+* ``dbxref.accession``
+* ``dbxref.version``
+* ``cvterm.cv_id``
+* ``cvterm.name``
+* ``cvterm.definition``
+* ``cvterm.dbxref_id``
+* ``cvterm.is_obsolete``
+* ``cvterm.is_relationshiptype``
+* ``buddy_record``
+
+Valid keys for ``$conditions`` only:
+
+* ``db.db_id``
+* ``db.name``
+* ``db.description``
+* ``db.url``
+* ``db.urlprefix``
+* ``dbxref.dbxref_id``
+* ``dbxref.db_id``
+* ``cv.cv_id``
+* ``cv.name``
+* ``cv.definition``
+* ``cvterm.cvterm_id``
+
+Valid keys for ``$options``:
+
+ * ``create_cvterm`` - set to TRUE (default FALSE) if you want to
+   automatically create a dbxref and cvterm if one does not already exist.
+
+
+upsertProperty()
+^^^^^^^^^^^^^^^^^^
+
+Updates a record if it exists, or inserts it if it does not, in the chado linker table.
+Only keys designated with a Ⓠ are used for the query to find the record to update if it already exists.
+
+Usage: ``$chado_buddy_records = $cvterm_instance->insertProperty($base_table, $record_id, $values, $options);``
+
+Valid keys for ``$values``:
+
+* ``db.db_id``
+* ``db.name`` Ⓠ
+* ``db.description``
+* ``db.url``
+* ``db.urlprefix``
+* ``dbxref.db_id`` Ⓠ
+* ``dbxref.description``
+* ``dbxref.accession`` Ⓠ
+* ``dbxref.version`` Ⓠ
+* ``cv.cv_id``
+* ``cv.name`` Ⓠ
+* ``cv.definition``
+* ``cvterm.cv_id`` Ⓠ
+* ``cvterm.name`` Ⓠ
+* ``cvterm.definition``
+* ``cvterm.dbxref_id`` Ⓠ
+* ``cvterm.is_obsolete`` Ⓠ
+* ``cvterm.is_relationshiptype``
+* ``buddy_record``
+
+Required keys to upsert a new record:
+
+* either ``db.db_id`` or ``dbxref.db_id`` or ``db.name``
+* either ``dbxref.dbxref_id`` or ``cvterm.dbxref_id`` or ``dbxref.accession``
+* either ``cv.cv_id`` or ``cvterm.cv_id`` or ``cv.name``
+* ``cvterm.name``


### PR DESCRIPTION
This is a small change to `conf.py` to get the copyright year from the current time.
I also changed copyright to a range starting at 2009 the year of the first public tripal release 😁
![2024-08-27_issue31](https://github.com/user-attachments/assets/9583bb7b-c305-43a9-81ad-c12c9ffee5b3)

I updated the version too, but this remains hardcoded because there is no easy way to get that automatically.

And I somehow goofed up the branch name 🙈