### PR TITLE
Organism Autocomplete Controller Deprecation Docs Update

### DIFF
--- a/docs/dev_guide/deprecations.rst
+++ b/docs/dev_guide/deprecations.rst
@@ -15,3 +15,9 @@ Several of Tripal 4.x's functions have been modified, deprecating their older ve
    :caption: Removed in Tripal 4.1.0:
 
    deprecations/chado_query_api
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Removed in Tripal 4.1.0:
+
+   deprecations/organism_autocomplete

--- a/docs/dev_guide/deprecations/organism_autocomplete.rst
+++ b/docs/dev_guide/deprecations/organism_autocomplete.rst
@@ -1,0 +1,70 @@
+## ChadoOrganismAutocompleteController is deprecated in favour of ChadoOrganismFormElementController
+
+- **Deprecated in** {tripal 4.0.0-alpha3}
+- **Removed in** {tripal 4.1.0}
+- **Issue** `#2284 <https://github.com/tripal/tripal/issues/2284>`_
+- **PR** `#2293 <https://github.com/tripal/tripal/pull/2293>`_
+
+The ChadoOrganismFormElementController class replaces the functionality of the existing ChadoOrganismAutocompleteController. It retains all existing methods with the same functionality. This class was created as an extension of the original class, and all method calls can be directly replaced without any changes.
+
+ChadoOrganismAutocompleteController::handleAutocomplete()
+--------------
+
+**Before:**
+
+.. code-block:: php
+
+  $organism_autocomplete = new ChadoOrganismAutocompleteController();
+  $request = Request::create(
+      'chado/organism/autocomplete/10',
+      'GET',
+      ['q' => 't']
+    );
+  $organism_autocomplete->handleAutocomplete($request, 5);
+
+
+**After:**
+
+.. code-block:: php
+
+  $organism_autocomplete = new ChadoOrganismFormElementController();
+  $request = Request::create(
+      'chado/organism/autocomplete/10',
+      'GET',
+      ['q' => 't']
+   );
+  $organism_autocomplete->handleAutocomplete($request, 5);
+
+
+ChadoOrganismAutocompleteController::getPkeyId()
+--------------
+
+**Before:**
+
+.. code-block:: php
+
+  $organism_id = ChadoOrganismAutocompleteController::getPkeyId('Tripalus databasica (1)');
+
+
+**After:**
+
+.. code-block:: php
+
+  $organism_id = ChadoOrganismFormElementController::getPkeyId('Tripalus databasica (1)');
+
+
+ChadoOrganismAutocompleteController::getQuery()
+--------------
+
+**Before:**
+
+.. code-block:: php
+
+  $query = ChadoOrganismAutocompleteController::getQuery('%', $options);
+
+
+**After:**
+
+.. code-block:: php
+
+  $query = ChadoOrganismFormElementController::getQuery('%', $options);

--- a/docs/dev_guide/deprecations/organism_autocomplete.rst
+++ b/docs/dev_guide/deprecations/organism_autocomplete.rst
@@ -1,7 +1,8 @@
-## ChadoOrganismAutocompleteController is deprecated in favour of ChadoOrganismFormElementController
+ChadoOrganismAutocompleteController is deprecated in favour of ChadoOrganismFormElementController
+======================================================================================================
 
-- **Deprecated in** {tripal 4.0.0-alpha3}
-- **Removed in** {tripal 4.1.0}
+- **Deprecated in** tripal 4.0.0-alpha3
+- **Removed in** tripal 4.1.0
 - **Issue** `#2284 <https://github.com/tripal/tripal/issues/2284>`_
 - **PR** `#2293 <https://github.com/tripal/tripal/pull/2293>`_
 

--- a/docs/dev_guide/deprecations/organism_autocomplete.rst
+++ b/docs/dev_guide/deprecations/organism_autocomplete.rst
@@ -9,7 +9,7 @@ ChadoOrganismAutocompleteController is deprecated in favour of ChadoOrganismForm
 The ChadoOrganismFormElementController class replaces the functionality of the existing ChadoOrganismAutocompleteController. It retains all existing methods with the same functionality. This class was created as an extension of the original class, and all method calls can be directly replaced without any changes.
 
 ChadoOrganismAutocompleteController::handleAutocomplete()
---------------
+-------------------------------------------------------------
 
 **Before:**
 
@@ -38,7 +38,7 @@ ChadoOrganismAutocompleteController::handleAutocomplete()
 
 
 ChadoOrganismAutocompleteController::getPkeyId()
---------------
+-----------------------------------------------------
 
 **Before:**
 
@@ -55,7 +55,7 @@ ChadoOrganismAutocompleteController::getPkeyId()
 
 
 ChadoOrganismAutocompleteController::getQuery()
---------------
+----------------------------------------------------
 
 **Before:**
 

--- a/docs/dev_guide/deprecations/organism_autocomplete.rst
+++ b/docs/dev_guide/deprecations/organism_autocomplete.rst
@@ -15,12 +15,16 @@ ChadoOrganismAutocompleteController::handleAutocomplete()
 
 .. code-block:: php
 
+  use Drupal\tripal_chado\Controller\ChadoOrganismAutocompleteController;
+  
+  ...
+
   $organism_autocomplete = new ChadoOrganismAutocompleteController();
   $request = Request::create(
-      'chado/organism/autocomplete/10',
-      'GET',
-      ['q' => 't']
-    );
+    'chado/organism/autocomplete/10',
+    'GET',
+    ['q' => 't']
+  );
   $organism_autocomplete->handleAutocomplete($request, 5);
 
 
@@ -28,12 +32,16 @@ ChadoOrganismAutocompleteController::handleAutocomplete()
 
 .. code-block:: php
 
+  use Drupal\tripal_chado\Controller\ChadoOrganismFormElementController;
+
+  ...
+
   $organism_autocomplete = new ChadoOrganismFormElementController();
   $request = Request::create(
-      'chado/organism/autocomplete/10',
-      'GET',
-      ['q' => 't']
-   );
+    'chado/organism/autocomplete/10',
+    'GET',
+    ['q' => 't']
+  );
   $organism_autocomplete->handleAutocomplete($request, 5);
 
 


### PR DESCRIPTION
This PR updates the tripal docs with the ChadoOrganismAutocompleteController deprecation.