### PR TITLE
Update docs to use attributes instead of annotations

### DIFF
--- a/docs/design/vocab/file-structure.rst
+++ b/docs/design/vocab/file-structure.rst
@@ -9,8 +9,13 @@ The base structure of this API is found in ``tripal/src/TripalVocabTerms/``. Spe
  - The **TripalTerm class**.
  - The **base classes** to extend when making your own vocabulary plugin implementation.
  - The **interfaces** you should implement are in the Interface directory and describe the methods you must implement in your vocabulary plugin implementation.
- - The **annotation classes** describe the metadata needed in the comment header of your implemented plugin class.
+ - The **attribute classes** describe the metadata needed in the attributes section of your implemented plugin class.
  - The **plugin managers** are in the PluginManager directory and simply link these plugins to the Drupal API.
+
+.. warning::
+
+  Support for the legacy **annotation classes** will be deprecated with Drupal 11.2 and support will be removed with
+  Drupal 12, so any existing annotations should be replaced with attributes.
 
 .. warning::
 

--- a/docs/dev_guide/biodata/importers.rst
+++ b/docs/dev_guide/biodata/importers.rst
@@ -224,7 +224,7 @@ Now that we have created the plugin and set its attributes it should appear in t
 
   If your importer does not show in the list of data loaders, check the Drupal recent logs at **admin > Manage > Reports > Recent log messages** .
 
-Using the attribute settings we provided, the importer form will automatically provide a **File Upload** field set, and an **Analysis** selector.  The **File Upload** section lets users choose to upload a file, provide a server path to a file already on the web server or a specify a remote path for files located via a downloadable link on the web.  The **Analysis** selector is important because it allows the user to specify an analysis that describes how the data file was created. It will look like the following screenshot:
+Using the attribute settings we provided, the importer form will automatically provide a **File Upload** field set, and an **Analysis** selector.  The **File Upload** section lets users choose to upload a file, provide a server path to a file already on the web server, or specify a remote path for files located via a downloadable link on the web.  The **Analysis** selector is important because it allows the user to specify an analysis that describes how the data file was created. It will look like the following screenshot:
 
 .. image:: custom_data_loader.1.png
 

--- a/docs/dev_guide/biodata/importers.rst
+++ b/docs/dev_guide/biodata/importers.rst
@@ -118,87 +118,105 @@ Notice in the ``form()`` function there is a call to the ``parent::form()``:
 
 Without calling the ``parent::form()`` function your importer's form may not properly work.  This is required.
 
-Step 4: Add Class Annotations
+Step 4: Add Class Attributes
 -----------------------------
-All Drupal plugins require an `Annotation section <https://www.drupal.org/docs/drupal-apis/plugin-api/annotations-based-plugins>`_ that appears as a PHP comment just above the Class definition. The annotation section provides settings that the **TripalImporter** plugin requires.  As a quick example here is the Annotation section for the GFF3 importer. The GFF3 importer is provided by the Tripal Genome module and imports features defined in a GFF3 file into Chado.
+All Drupal plugins require an
+`Attribute section <https://www.drupal.org/docs/drupal-apis/plugin-api/attribute-based-plugins>`_
+which consists of lines wrapped inside ``#[ ]`` just above the Class definition.
+The attribute section provides settings that the **TripalImporter** plugin requires.
+As a quick example here is the Attribute section for the GFF3 importer.
+The GFF3 importer is provided by the Tripal Genome module and imports features defined in a GFF3 file into Chado.
 
 .. code-block:: php
 
-  /**
-  *  GFF3 Importer implementation of the ChadoImporterBase.
-  *
-  *  @TripalImporter(
-  *    id = "chado_fasta_loader",
-  *    label = @Translation("Chado FASTA File Loader"),
-  *    description = @Translation("Import a FASTA file into Chado"),
-  *    file_types = {"fasta","txt","fa","aa","pep","nuc","faa","fna"},
-  *    upload_description = @Translation("Please provide a plain text file following the <a target='_blank' href='https://en.wikipedia.org/wiki/FASTA_format'>FASTA format specification</a>."),
-  *    upload_title = @Translation("FASTA File"),
-  *    use_analysis = True,
-  *    require_analysis = True,
-  *    use_button = True,
-  *    button_text = @Translation("Import FASTA file"),
-  *    file_upload = True,
-  *    file_remote = True,
-  *    file_local = True,
-  *    file_required = True,
-  *    submit_disabled = False
-  *  )
-  */
-  class GFF3Importer extends ChadoImporterBase {
+  use Drupal\Core\StringTranslation\TranslatableMarkup;
+  use Drupal\tripal\TripalImporter\Attribute\TripalImporter;
 
-In the code above, the annotation section consists of multiple settings in key/value pairs.  The meaning of each settings is as follows:
+  ...
+
+  /**
+   * GFF3 Importer implementation of the TripalImporterBase.
+   */
+  #[TripalImporter(
+    id: 'chado_gff3_loader',
+    label: new TranslatableMarkup('Chado GFF3 File Loader'),
+    description: new TranslatableMarkup('Import a GFF3 file into Chado'),
+    file_types: [
+      'gff',
+      'gff3',
+      'txt',
+    ],
+    upload_description: new TranslatableMarkup('Please provide a plain text, tab-delimited file following the <a target="_blank" href="https://github.com/The-Sequence-Ontology/Specifications/blob/master/gff3.md">GFF3 Specification</a>. It is expected that all landmark features are associated with the same organism and that the types (column 3) are sequence ontology terms.'),
+    upload_title: new TranslatableMarkup('GFF3 File'),
+    use_analysis: true,
+    require_analysis: true,
+    use_button: true,
+    button_text: new TranslatableMarkup('Import GFF3 file'),
+    file_upload: true,
+    file_remote: true,
+    file_local: true,
+    file_required: true,
+    publish: [
+      'bundle' => [
+        'gene',
+        'mrna',
+      ],
+    ],
+  )]
+  class GFF3Importer extends ChadoImporterBase implements ContainerFactoryPluginInterface {
+
+In the code above, the attribute section consists of multiple settings in key/value pairs.
+The meaning of each settings is as follows:
 
 - ``id``: A unique machine readable plugin ID for the loader. It must only contain alphanumeric characters and the underscore. It should be lowercase.  
-- ``label``: the human readable name (or label) for this importer. It is wrapped in a ``@Translation()`` function which will allow Drupal to provide translations for it.  This label is shown to the user in the list of available data importers.
+- ``label``: the human readable name (or label) for this importer. It is wrapped in a ``TranslatableMarkup()`` class which will allow Drupal to provide translations for it.  This label is shown to the user in the list of available data importers.
 - ``description``: A short description for the site user that briefly indicates what this loader is for. It too is wrapped in a ``@Translation()``  function.  This description is shown to the user for the loader.
 - ``file_types``: A list of file extensions that the importer will allow to be uploaded. If a file does not have an extension in the list then it cannot be uploaded by the importer.
 - ``upload_title``:  Provides the title that should appear above the upload button.  This helps the user understand what type of file is expected.
 - ``upload_description``: Provides the information for the user related to the file upload. You can provide additional instructions or help text.
 - ``use_analysis``:  To support FAIR data principles, we should ensure that provenance of data is available. Chado provides the ``analysis`` table to link data to an analysis.  The analysis record provides the details for how the data in the file was created or obtained. Set this to ``False`` if the loader should not require an analysis when loading. if ``use_analysis`` is set to ``True`` then the user will be presented with a form element to select an analysis and this analysis will be available to you for your importer.
 - ``require_analysis``:  If the ``use_analysis`` value is set then this value indicates if the analysis should be required. If ``True`` it will be required, otherwise it will be optional.
-- ``button_text``: The text that should appear on the button at the bottom of the importer form.
 - ``use_button``: Indicates whether a submit button should be present. This should only be ``False`` in situations were you need multiple buttons or greater control over the submit process (e.g., multi-page forms).
+- ``button_text``: The text that should appear on the button at the bottom of the importer form.
 - ``submit_disabled``: Indicates whether the submit button should be disabled when the form appears. The form can then be programmatically enabled via AJAX once certain criteria is set.
 - ``file_upload``: Indicates if the loader should provide a form element for uploading a file.
 - ``file_remote``: Indicates if the loader should provide a form element for specifying the URL of a remote file.
 - ``file_local``: Indicates if the loader should provide a form element for specifying the path available to the web server where the file is located.
-- ``file_required``:  Indicates if the file must be provided. 
+- ``file_required``: Indicates if the file must be provided.
+- ``publish``: Indicates any content types that should be published after the import job has completed.
 
-For our ``ExampleImporter`` class we will set the annotations accordingly:
+For our ``ExampleImporter`` class we will set the attributes accordingly:
 
 .. code-block:: php
 
   /**
     *  TST Importer implementation of the ChadoImporterBase.
-    *
-    *  @TripalImporter(
-    *    id = "tripal_tst_loader",
-    *    label = @Translation("Example TST File Importer"),
-    *    description = @Translation("Loads TST files"),
-    *    file_types = {"txt", "tst", "csv"},
-    *    upload_description = @Translation("TST is a fictional format.  Its a 2-column, CSV file.  The columns should be of the form featurename, and text"),
-    *    upload_title = @Translation("TST File"),
-    *    use_analysis = True,
-    *    require_analysis = True,
-    *    use_button = True,
-    *    button_text = @Translation("Import TST file"),
-    *    file_upload = True,
-    *    file_remote = True,
-    *    file_local = True,
-    *    file_required = True,
-    *    submit_disabled = False
-    *  )
     */
-    class ExampleImporter extends ChadoImporterBase {
-
-.. warning::
-
-  You must use double quotes when specifying strings in the Annotations.
+  #[TripalImporter(
+    id: 'tripal_tst_loader',
+    label: new TranslatableMarkup('Example TST File Importer'),
+    description: new TranslatableMarkup('Loads TST files'),
+    file_types: [
+      'txt',
+      'tst',
+      'csv',
+    ],
+    upload_description: new TranslatableMarkup('TST is a fictional format. It is a 2-column, CSV file. The columns should be of the form featurename, and text'),
+    upload_title: new TranslatableMarkup('TST File'),
+    use_analysis: true,
+    require_analysis: true,
+    button_text: new TranslatableMarkup('Import TST file'),
+    file_upload: true,
+    file_remote: true,
+    file_local: true,
+    file_required: true,
+    submit_disabled: false,
+  )]
+  class ExampleImporter extends ChadoImporterBase {
 
 Step 5: Check Availability
 --------------------------
-Now that we have created the plugin and set it's annotations it should appear in the list of Tripal Importers at **admin > Tripal > Data Loaders** after we clear the Drupal cache (``drush cr``). 
+Now that we have created the plugin and set its attributes it should appear in the list of Tripal Importers at **admin > Tripal > Data Loaders** after we clear the Drupal cache (``drush cr``). 
 
 .. image:: ./custom_data_loader.0.png
 
@@ -206,7 +224,7 @@ Now that we have created the plugin and set it's annotations it should appear in
 
   If your importer does not show in the list of data loaders, check the Drupal recent logs at **admin > Manage > Reports > Recent log messages** .
 
-Using the annotation settings we provided, the importer form will automatically provide a **File Upload** field set, and an **Analysis** selector.  The **File Upload** section lets users choose to upload a file, provide a server path to a file already on the web server or a specify a remote path for files located via a downloadable link on the web.  The **Analysis** selector is important because it allows the user to specify an analysis that describes how the data file was created. It will look like the following screenshot:
+Using the attribute settings we provided, the importer form will automatically provide a **File Upload** field set, and an **Analysis** selector.  The **File Upload** section lets users choose to upload a file, provide a server path to a file already on the web server or a specify a remote path for files located via a downloadable link on the web.  The **Analysis** selector is important because it allows the user to specify an analysis that describes how the data file was created. It will look like the following screenshot:
 
 .. image:: custom_data_loader.1.png
 
@@ -520,7 +538,7 @@ For our example importer, the following code shows how we can test the form:
     $this->assertArrayHasKey('#title', $form, 
       "The form should have a title set.");
     $this->assertEquals($importer_label, $form['#title'], 
-      "The title should match the label annotated for our plugin.");
+      "The title should match the label in the attribute for our plugin.");
     
     // The plugin_id stored in a value form element.
     $this->assertArrayHasKey('importer_plugin_id', $form, 

--- a/docs/dev_guide/module_dev/fields/formatters.rst
+++ b/docs/dev_guide/module_dev/fields/formatters.rst
@@ -25,20 +25,25 @@ The following is a simple class example:
   namespace Drupal\tripal_chado\Plugin\Field\FieldFormatter;
 
   use Drupal\Core\Field\FieldItemListInterface;
+  use Drupal\Core\StringTranslation\TranslatableMarkup;
+  use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
   use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
 
   /**
    * Plugin implementation of an organism scientific name formatter.
-   *
-   * @FieldFormatter(
-   *   id = "my_field_formatter",
-   *   label = @Translation("Organism scientific name formatter"),
-   *   description = @Translation("A chado organism scientific name formatter"),
-   *   field_types = {
-   *     "my_field"
-   *   },
-   * )
    */
+  #[TripalFieldFormatter(
+    id: 'my_field_formatter',
+    label: new TranslatableMarkup('Organism scientific name formatter'),
+    description: new TranslatableMarkup('A chado organism scientific name formatter'),
+    field_types: [
+      'my_field',
+    ],
+    valid_tokens: [
+      '[genus]',
+      '[species]',
+    ],
+  )]
   class MyFieldFormatter extends ChadoFormatterBase {
 
     /**
@@ -110,10 +115,12 @@ field.
 
   If you misspell the `namespace` your field will not work properly.
 
-The following "use" statement is required for all Chado fields.
+The following "use" statements are required for all Chado fields.
 
 .. code-block:: php
 
+  use Drupal\Core\StringTranslation\TranslatableMarkup;
+  use Drupal\tripal\TripalField\Attribute\TripalFieldFormatter;
   use Drupal\tripal_chado\TripalField\ChadoFormatterBase;
 
 Unless you are sure that your field will only handle a single value in all
@@ -124,28 +131,31 @@ formatter to handle a list of multiple items.
 
   use Drupal\Core\Field\FieldItemListInterface;
 
-Formatter Annotation Section
-``````````````````````````````
-The annotation section in the class file is the set of in-line comments for the class.
-This annotation is required.
-This section is similar to the annotation section in the previous Type class.
-Note the ``field_types`` annotation, which specifies what field types this formatter can be used
-for. This should match the ``id`` annotation in the Type class.
+Formatter Attribute Section
+`````````````````````````````
+The attribute section in the class file is the set of lines wrapped inside ``#[ ]``.
+The attribute section is required.
+This section is similar to the attribute section in the previous Type class.
+Note the ``field_types`` attribute, which specifies what field types this formatter can be used
+for. This should match the ``id`` attribute in the Type class.
 
 .. code-block:: php
 
   /**
    * Plugin implementation of an organism scientific name formatter.
-   *
-   * @FieldFormatter(
-   *   id = "my_field_formatter",
-   *   label = @Translation("Organism scientific name formatter"),
-   *   description = @Translation("A chado organism scientific name formatter"),
-   *   field_types = {
-   *     "my_field"
-   *   },
-   * )
    */
+  #[TripalFieldFormatter(
+    id: 'my_field_formatter',
+    label: new TranslatableMarkup('Organism scientific name formatter'),
+    description: new TranslatableMarkup('A chado organism scientific name formatter'),
+    field_types: [
+      'my_field',
+    ],
+    valid_tokens: [
+      '[genus]',
+      '[species]',
+    ],
+  )]
 
 .. note::
 
@@ -155,7 +165,7 @@ for. This should match the ``id`` annotation in the Type class.
 
 .. warning::
 
-   If the annotation section is not present, has misspellings, or is not
+   If the attribute section is not present, has misspellings, or is not
    complete, the field will not be recognized by Drupal.
 
 Formatter Class Definition

--- a/docs/dev_guide/module_dev/fields/types.rst
+++ b/docs/dev_guide/module_dev/fields/types.rst
@@ -28,7 +28,7 @@ Tripal provides some ready-to-use field classes for single-values.  These are:
 
 .. warning::
 
-  The alpha v2 version of Tripal v4 does not yet implement these fields:
+  The alpha v3 version of Tripal v4 does not yet implement these fields:
   `ChadoRealTypeDefault`, `ChadoDateTimeTypeDefault`
 
 If you need to add a single-value field for your custom module then you do not
@@ -75,23 +75,25 @@ The following is a simple class example:
 
   namespace Drupal\mymodule\Plugin\Field\FieldType;
 
+  use Drupal\Core\StringTranslation\TranslatableMarkup;
+  use Drupal\tripal\TripalField\Attribute\TripalFieldType;
+  use Drupal\tripal\TripalStorage\StoragePropertyValue;
   use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
-  use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;
   use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
   use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;
-  use Drupal\tripal\TripalStorage\StoragePropertyValue;
+  use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;
 
   /**
-   * Plugin implementation of Tripal string field type.
-   *
-   * @FieldType(
-   *   id = "my_field",
-   *   label = @Translation("MyField Field"),
-   *   description = @Translation("An example field"),
-   *   default_widget = "MyFieldWidget",
-   *   default_formatter = "MyFieldFormatter"
-   * )
+   * Plugin implementation of example MyField field type.
    */
+  #[TripalFieldType(
+    id: 'my_field',
+    category: 'tripal_chado',
+    label: new TranslatableMarkup('MyField Field'),
+    description: new TranslatableMarkup('An example field'),
+    default_widget: 'my_field_widget',
+    default_formatter: 'my_field_formatter',
+  )]
   class MyField extends ChadoFieldItemBase {
 
     public static $id = "my_field";
@@ -181,7 +183,6 @@ field.
 
   namespace Drupal\mymodule\Plugin\Field\FieldType;
 
-
 .. note::
 
   Be sure to change `mymodule` in the `namespace` to the name of your module.
@@ -195,6 +196,8 @@ The following "use" statements are required for all Chado fields.
 
 .. code-block:: php
 
+  use Drupal\Core\StringTranslation\TranslatableMarkup;
+  use Drupal\tripal\TripalField\Attribute\TripalFieldType;
   use Drupal\tripal_chado\TripalField\ChadoFieldItemBase;
   use Drupal\tripal\TripalStorage\StoragePropertyValue;
 
@@ -204,37 +207,34 @@ classes you could import if needed.
 
 .. code-block:: php
 
-  use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;
   use Drupal\tripal_chado\TripalStorage\ChadoIntStoragePropertyType;
   use Drupal\tripal_chado\TripalStorage\ChadoTextStoragePropertyType;
+  use Drupal\tripal_chado\TripalStorage\ChadoVarCharStoragePropertyType;
 
 
-Type Annotation Section
-`````````````````````````
+Type Attribute Section
+````````````````````````
 
-The annotation section in the class file is the set of in-line comments for the class.
-Note the @FieldType stanza in the comments. Drupal
-uses these annotations to recognize the new field. It provides information such
+The attribute section in the class file is the set of lines wrapped inside ``#[ ]``.
+The attribute section is required.
+Drupal uses these attributes to recognize the new field. It provides information such
 as the field ID, label and description. It also indicates the default widget
-and formatter class. This annotation is required.
+and formatter class.
 
 .. code-block:: php
 
-  /**
-   * Plugin implementation of Tripal string field type.
-   *
-   * @FieldType(
-   *   id = "MyField",
-   *   label = @Translation("MyField Field"),
-   *   description = @Translation("An example field"),
-   *   default_widget = "MyFieldWidget",
-   *   default_formatter = "MyFieldFormatter"
-   * )
-   */
+  #[TripalFieldType(
+    id: 'my_field',
+    category: 'tripal_chado',
+    label: new TranslatableMarkup('MyField Field'),
+    description: new TranslatableMarkup('An example field'),
+    default_widget: 'my_field_widget',
+    default_formatter: 'my_field_formatter',
+  )]
 
 .. warning::
 
-   If the annotation section is not present, has misspellings, or is not
+   If the attribute section is not present, has misspellings, or is not
    complete, the field will not be recognized by Drupal.
 
 

--- a/docs/dev_guide/module_dev/fields/widgets.rst
+++ b/docs/dev_guide/module_dev/fields/widgets.rst
@@ -228,7 +228,7 @@ organism is presented as the default.
 The massageFormValues() function
 ``````````````````````````````````
 
-This function is called afther the form is submitted by the user, and takes care of
+This function is called after the form is submitted by the user, and takes care of
 removing any records that may have been present earlier, but were removed before saving.
 This is a simple example, but your field may need to do more, particularly if the field
 is referencing a linked table.

--- a/docs/dev_guide/module_dev/fields/widgets.rst
+++ b/docs/dev_guide/module_dev/fields/widgets.rst
@@ -20,22 +20,23 @@ The following is a simple class example:
 
   namespace Drupal\mymodule\Plugin\Field\FieldWidget;
 
+  use Drupal\Core\StringTranslation\TranslatableMarkup;
   use Drupal\Core\Field\FieldItemListInterface;
   use Drupal\Core\Form\FormStateInterface;
+  use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
   use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 
   /**
    * Plugin implementation of organism name widget.
-   *
-   * @FieldWidget(
-   *   id = "my_field_widget",
-   *   label = @Translation("Organism Scientific Name Widget"),
-   *   description = @Translation("A chado organism scientific name widget."),
-   *   field_types = {
-   *     "my_field"
-   *   }
-   * )
    */
+  #[TripalFieldWidget(
+    id: 'my_field_widget',
+    label: new TranslatableMarkup('Organism Scientific Name Widget'),
+    description: new TranslatableMarkup('A chado organism scientific name widget.'),
+    field_types: [
+      'my_field',
+    ],
+  )]
   class MyFieldWidget extends ChadoWidgetBase {
 
     /**
@@ -111,36 +112,37 @@ The following "use" statements are required for all Chado fields.
 
 .. code-block:: php
 
+  use Drupal\Core\StringTranslation\TranslatableMarkup;
   use Drupal\Core\Field\FieldItemListInterface;
   use Drupal\Core\Form\FormStateInterface;
+  use Drupal\tripal\TripalField\Attribute\TripalFieldWidget;
   use Drupal\tripal_chado\TripalField\ChadoWidgetBase;
 
-Widget Annotation Section
-``````````````````````````````
-The annotation section in the class file is the set of in-line comments for the class.
-This annotation is required.
-This section is similar to the annotation section in the previous Type and Formatter classes.
-Note the ``field_types`` annotation, which specifies what field types this formatter can be used
-for. This should match the ``id`` annotation in the Type class.
+Widget Attribute Section
+``````````````````````````
+The attribute section in the class file is the set of lines wrapped inside ``#[ ]``.
+The attribute section is required.
+This section is similar to the attribute section in the previous Type and Formatter classes.
+Note the ``field_types`` attribute, which specifies what field types this formatter can be used
+for. This should match the ``id`` attribute in the Type class.
 
 .. code-block:: php
 
   /**
    * Plugin implementation of organism name widget.
-   *
-   * @FieldWidget(
-   *   id = "my_field_widget",
-   *   label = @Translation("Organism Scientific Name Widget"),
-   *   description = @Translation("A chado organism scientific name widget."),
-   *   field_types = {
-   *     "my_field"
-   *   }
-   * )
    */
+  #[TripalFieldWidget(
+    id: 'my_field_widget',
+    label: new TranslatableMarkup('Organism Scientific Name Widget'),
+    description: new TranslatableMarkup('A chado organism scientific name widget.'),
+    field_types: [
+      'my_field',
+    ],
+  )]
 
 .. warning::
 
-   If the annotation section is not present, has misspellings, or is not
+   If the attribute section is not present, has misspellings, or is not
    complete, the field will not be recognized by Drupal.
 
 Widget Class Definition


### PR DESCRIPTION
Closes #122 

Annotations are deprecated with Drupal 11.2 and will be dropped from Drupal 12.

All of the existing annotations in examples have been replaced with attributes.