### PR TITLE
Documentation for Defining Schema for New Fields

### DIFF
--- a/docs/dev_guide/module_dev/fields/formatters.rst
+++ b/docs/dev_guide/module_dev/fields/formatters.rst
@@ -274,3 +274,15 @@ for this new field to allow editing content.
   A good way to learn about fields is to look at examples of fields in the Tripal
   core codebase. Specifically, look in the
   `tripal_chado/src/Plugin/Field/FieldFormatter` directory.
+
+
+Field Formatter Schema
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Field formatter schema is required to make field formatter information translatable in Drupal. The schema is defined in ``config/schema/mymodule.schema.yml`` and should include the following:
+
+.. code-block:: yaml
+
+  field.formatters.settings.my_field_formatters:
+    type: mapping
+    mapping: {}

--- a/docs/dev_guide/module_dev/fields/formatters.rst
+++ b/docs/dev_guide/module_dev/fields/formatters.rst
@@ -279,7 +279,7 @@ for this new field to allow editing content.
 Field Formatter Schema
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Field formatter schema is required to make field formatter information translatable in Drupal. The schema is defined in ``config/schema/mymodule.schema.yml`` and should include the following:
+A schema definition for your field formatter is required to make field formatter information translatable in Drupal. The schema is defined in ``config/schema/mymodule.schema.yml`` and should include the following:
 
 .. code-block:: yaml
 

--- a/docs/dev_guide/module_dev/fields/types.rst
+++ b/docs/dev_guide/module_dev/fields/types.rst
@@ -297,7 +297,7 @@ in the example above.  A field can be re-used for different terms and those
 can be set when the field is added automatically. See the
 :ref:`Adding a field programatically` section.
 
-If you add any custom settings here for your field then you will need to add them to the schema definition in ``config/schema/mymodule.schema.yml``. For example, if you added a ``max_delta`` setting here which `indicates the number of entries to populate` as shown here:
+If you add any custom settings here for your field, then you will need to add them to the schema definition in ``config/schema/mymodule.schema.yml``. For example, if you added a ``max_delta`` setting here which `indicates the number of entries to populate` as shown here:
 
 .. code-block:: php
 
@@ -308,7 +308,7 @@ If you add any custom settings here for your field then you will need to add the
     return $settings + parent::defaultFieldSettings();
   }
 
-Then you would need to expand the schema definition for this field in ``config/schema/mymodule.schema.yml`` like this:
+Then you would need to expand the schema definition for this field in ``config/schema/mymodule.schema.yml`` as shown below:
 
 .. code-block:: yaml
 
@@ -360,7 +360,7 @@ function from this field:
     return $settings;
   }
 
-If you add any custom storage settings here for your field then you will need to add them to the schema definition in ``config/schema/mymodule.schema.yml``. For example, if you added a ``prop_table`` setting as shown here:
+If you add any custom storage settings here for your field, then you will need to add them to the schema definition in ``config/schema/mymodule.schema.yml``. For example, if you added a ``prop_table`` setting as shown here:
 
 .. code-block:: php
 
@@ -819,7 +819,7 @@ that uses a tokenized string to create the full scientific name for the organism
 Field Type Schema
 ^^^^^^^^^^^^^^^^^^^
 
-When creating a new field you need to add schema for the `field settings` and `field storage settings`. This is done by adding two stanzas to the ``config/schema/mymodule.schema.yml`` file as follows where the field machine name is ``my_field``.
+When creating a new field you need to add schema for the `field settings` and `field storage settings`. This is done by adding two stanzas to the ``config/schema/mymodule.schema.yml`` file as follows, where the field machine name is ``my_field``.
 
 .. code-block:: yaml
 
@@ -833,7 +833,7 @@ When creating a new field you need to add schema for the `field settings` and `f
 
 By defining these, the default schema will be added dynamically as defined by Tripal core. Specifically,
 
-Field Storage:
+**Field Storage:**
 
 .. code-block:: yaml
 
@@ -854,7 +854,7 @@ Field Storage:
       type: mapping
       label: 'Tripal Storage-specific Settings'   
 
-Field Settings:
+**Field Settings:**
 
 .. code-block:: yaml
 

--- a/docs/dev_guide/module_dev/fields/types.rst
+++ b/docs/dev_guide/module_dev/fields/types.rst
@@ -297,6 +297,28 @@ in the example above.  A field can be re-used for different terms and those
 can be set when the field is added automatically. See the
 :ref:`Adding a field programatically` section.
 
+If you add any custom settings here for your field then you will need to add them to the schema definition in ``config/schema/mymodule.schema.yml``. For example, if you added a ``max_delta`` setting here which `indicates the number of entries to populate` as shown here:
+
+.. code-block:: php
+
+  public static function defaultFieldSettings() {
+    $settings = [
+      'max_delta' => 100,
+    ];
+    return $settings + parent::defaultFieldSettings();
+  }
+
+Then you would need to expand the schema definition for this field in ``config/schema/mymodule.schema.yml`` like this:
+
+.. code-block:: yaml
+
+  field.field_settings.my_field:
+    type: mapping
+    mapping:
+      max_delta:
+        type: integer
+        label: 'Maximum number of items to populate'
+
 The defaultStorageSettings() Function
 ```````````````````````````````````````
 The field settings described in the previous function apply to the field. But
@@ -337,6 +359,32 @@ function from this field:
     $settings['storage_plugin_settings']['base_column'] = '';
     return $settings;
   }
+
+If you add any custom storage settings here for your field then you will need to add them to the schema definition in ``config/schema/mymodule.schema.yml``. For example, if you added a ``prop_table`` setting as shown here:
+
+.. code-block:: php
+
+  public static function defaultStorageSettings() {
+    $settings = parent::defaultStorageSettings();
+    $settings['storage_plugin_settings']['prop_table'] = '';
+    return $settings;
+  }
+
+Then you would need to expand the schema definition for this field in ``config/schema/mymodule.schema.yml`` similar to above. But it is added to the ``field storage settings``:
+
+.. code-block:: yaml
+
+  field.storage_settings.my_field:
+    type: mapping
+    mapping:
+      storage_plugin_settings:
+        type: mapping
+        label: 'Tripal Storage-specific Settings'
+        mapping:
+          prop_table:
+            type: 'string'
+            label: 'Table containing property columns'
+            nullable: FALSE
 
 The storageSettingsForm() Function
 ````````````````````````````````````
@@ -762,5 +810,69 @@ that uses a tokenized string to create the full scientific name for the organism
   core codebase. Specifically, look in the
   `tripal_chado/src/Plugin/Field/FieldType` directory.
 
+.. note::
+
+  Field schema are needed to allow your field information to be translatable in Drupal. 
+  Additionally, without these schema definitions, you will get schema errors in 
+  your automated tests.
+
+Field Type Schema
+^^^^^^^^^^^^^^^^^^^
+
+When creating a new field you need to add schema for the `field settings` and `field storage settings`. This is done by adding two stanzas to the ``config/schema/mymodule.schema.yml`` file as follows where the field machine name is ``my_field``.
+
+.. code-block:: yaml
+
+    field.field_settings.my_field:
+      type: mapping
+      mapping: {}
+
+    field.storage_settings.my_field:
+      type: mapping
+      mapping: {}
+
+By defining these, the default schema will be added dynamically as defined by Tripal core. Specifically,
+
+Field Storage:
+
+.. code-block:: yaml
+
+    termIdSpace:
+      type: string
+      label: 'Term ID Space'
+    termAccession:
+      type: string
+      label: 'Term Accession'
+    debug:
+      type: boolean
+      label: 'Flag to Enable field debugging'
+      nullable: true
+    storage_plugin_id:
+      type: string
+      label: 'Tripal Storage Plugin Machine Name'
+    storage_plugin_settings:
+      type: mapping
+      label: 'Tripal Storage-specific Settings'   
+
+Field Settings:
+
+.. code-block:: yaml
+
+    termIdSpace:
+      type: string
+      label: 'Term ID Space'
+    termAccession:
+      type: string
+      label: 'Term Accession'
+    debug:
+      type: boolean
+      label: 'Flag to Enable field debugging'
+      nullable: true
+    fixed_value:
+      type: string
+      label: 'A fixed value to use for the term Id Space and Accession for this field (e.g. data:1278).'
+      nullable: true
+
 The next section :ref:`Field Formatters` will describe how to create a formatter
 for this new field.
+

--- a/docs/dev_guide/module_dev/fields/widgets.rst
+++ b/docs/dev_guide/module_dev/fields/widgets.rst
@@ -258,3 +258,15 @@ is referencing a linked table.
   A good way to learn about fields is to look at examples of fields in the Tripal
   core codebase. Specifically, look in the
   `tripal_chado/src/Plugin/Field/FieldWidget` directory.
+
+
+Field Widget Schema
+^^^^^^^^^^^^^^^^^^^^^
+
+Field widget schema is required to make field widget information translatable in Drupal. The schema is defined in ``config/schema/mymodule.schema.yml`` and should include the following:
+
+.. code-block:: yaml
+
+  field.widget.settings.my_field_widget:
+    type: mapping
+    mapping: {}

--- a/docs/dev_guide/module_dev/fields/widgets.rst
+++ b/docs/dev_guide/module_dev/fields/widgets.rst
@@ -263,7 +263,7 @@ is referencing a linked table.
 Field Widget Schema
 ^^^^^^^^^^^^^^^^^^^^^
 
-Field widget schema is required to make field widget information translatable in Drupal. The schema is defined in ``config/schema/mymodule.schema.yml`` and should include the following:
+A schema definition for your field widget is required to make field widget information translatable in Drupal. The schema is defined in ``config/schema/mymodule.schema.yml`` and should include the following:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
Closes **Issue #140**

This adds documentation on how to add the schema definition for new fields.

The following is added under each section below:

Field Types: 

<img width="845" height="941" alt="Screenshot 2026-06-10 at 3 04 08 PM" src="https://github.com/user-attachments/assets/b6fc790a-0e3b-4e6a-980d-81e5d7db126c" />

The defaultFieldSettings() Function section:
<img width="623" height="375" alt="Screenshot 2026-06-10 at 3 02 54 PM" src="https://github.com/user-attachments/assets/a75f3cef-c3c6-4749-91c8-323a4d62608a" />

The defaultStorageSettings() Function:
<img width="626" height="454" alt="Screenshot 2026-06-10 at 3 03 03 PM" src="https://github.com/user-attachments/assets/989925c9-233e-49a5-a323-e720a6bb2fab" />

Field Formatters:
<img width="758" height="239" alt="Screenshot 2026-06-10 at 3 03 31 PM" src="https://github.com/user-attachments/assets/ebcc25a1-e2f8-41da-9f69-9ba1156aba1d" />

Field Widgets:
<img width="765" height="238" alt="Screenshot 2026-06-10 at 3 03 41 PM" src="https://github.com/user-attachments/assets/78840a0e-3e09-437a-92c7-8fd0e155a006" />
