### PR TITLE
Documentation for replacing the Old Chado Organism API methods with new OOP methods

### DIFF
--- a/docs/dev_guide/deprecations.rst
+++ b/docs/dev_guide/deprecations.rst
@@ -17,4 +17,5 @@ Several of Tripal 4.x's functions have been modified, deprecating their older ve
    deprecations/chado_query_api
    deprecations/tripalimporter_dev_inj_constructor
    deprecations/organism_autocomplete
+   deprecations/chado_organism_api
 

--- a/docs/dev_guide/deprecations/chado_organism_api.rst
+++ b/docs/dev_guide/deprecations/chado_organism_api.rst
@@ -1,0 +1,128 @@
+Tripal Chado Organism API is deprecated in favour of the ChadoOrganismBuddy and ChadoOrganismFormElementController
+===================================================================================================================
+
+- **Deprecated in** tripal 4.0.0-alpha4
+- **Removed in** tripal 4.1.0
+- **Issue** `#2424 <https://github.com/tripal/tripal/issues/2424>`_
+- **PR** `#2426 <https://github.com/tripal/tripal/pull/2426>`_
+
+Methods in ChadoOrganismBuddy class and ChadoOrganismFormElementController class replace the functionality of the existing Chado Organism API methods.
+
+chado_get_organism()
+--------------------
+
+**Before:**
+
+.. code-block:: php
+
+    $identifiers = [
+        'genus' => 'Lens',
+        'species' => 'culinaris',
+    ];
+    $organism = chado_get_organism($identifiers, []);
+
+**After:**
+
+.. code-block:: php
+
+    $buddy_service = \Drupal::service('tripal_chado.chado_buddy');
+    $organism_buddy_instance = $buddy_service->createInstance('chado_organism_buddy', []);
+
+    $conditions = [
+        'organism.genus' => 'Lens',
+        'organism.species' => 'culinaris',
+    ];
+    $organism = $organism_buddy_instance->getOrganism($conditions, []);
+
+
+chado_get_organism_scientific_name()
+------------------------------------
+
+**Before:**
+
+.. code-block:: php
+
+    $organism = chado_get_organism_scientific_name($organism_object);
+
+**After:**
+
+.. code-block:: php
+
+    $buddy_service = \Drupal::service('tripal_chado.chado_buddy');
+    $organism_buddy_instance = $buddy_service->createInstance('chado_organism_buddy', []);
+
+    $organism = $organism_buddy_instance->getOrganismScientificName($organism_object, []);
+
+chado_get_organism_select_options()
+-----------------------------------
+
+**Before:**
+
+.. code-block:: php
+
+    $organisms = chado_get_organism_select_options();
+
+**After:**
+
+.. code-block:: php
+
+  use Drupal\tripal_chado\Controller\ChadoOrganismFormElementController;
+
+  ...
+
+  $organisms = ChadoOrganismFormElementController::getSelectOptions([]);
+
+chado_get_organism_id_from_scientific_name()
+--------------------------------------------
+
+**Before:**
+
+.. code-block:: php
+
+    $organism_id = chado_get_organism_id_from_scientific_name($scientific_name, $options);
+
+**After:**
+
+.. code-block:: php
+
+    $buddy_service = \Drupal::service('tripal_chado.chado_buddy');
+    $organism_buddy_instance = $buddy_service->createInstance('chado_organism_buddy', []);
+
+    $organism_id = $organism_buddy_instance->getOrganismFromScientificName($scientific_name, $options);
+
+chado_abbreviate_infraspecific_rank()
+-------------------------------------
+
+**Before:**
+
+.. code-block:: php
+
+    $abbreviation = chado_abbreviate_infraspecific_rank($rank_species);
+
+**After:**
+
+.. code-block:: php
+
+    $buddy_service = \Drupal::service('tripal_chado.chado_buddy');
+    $organism_buddy_instance = $buddy_service->createInstance('chado_organism_buddy', []);
+
+    $abbreviation = $organism_buddy_instance->abbreviateInfraspecificRank($rank_species);
+
+chado_unabbreviate_infraspecific_rank()
+----------------------------------------
+
+**Before:**
+
+.. code-block:: php
+
+    $rank = chado_unabbreviate_infraspecific_rank($rank_species);
+
+**After:**
+
+.. code-block:: php
+
+    $buddy_service = \Drupal::service('tripal_chado.chado_buddy');
+    $organism_buddy_instance = $buddy_service->createInstance('chado_organism_buddy', []);
+
+    $rank = $organism_buddy_instance->unabbreviateInfraspecificRank($rank_species);
+

--- a/docs/dev_guide/deprecations/chado_organism_api.rst
+++ b/docs/dev_guide/deprecations/chado_organism_api.rst
@@ -8,10 +8,10 @@ Tripal Chado Organism API is deprecated in favour of the ChadoOrganismBuddy and 
 
 Methods in ChadoOrganismBuddy and ChadoOrganismFormElementController classes replace the majority of the functionality of the existing Chado Organism API methods. 
 
-Some of these methods can be provided a ChadyBuddyRecord as a parameter, and may return one or more Organism buddies. To learn more about ChadoBuddies, refer to: `Chado Buddies Documentation <https://tripaldoc.readthedocs.io/en/latest/dev_guide/biodata/buddies.html>`_
+Some of these methods can be provided a ChadyBuddyRecord as a parameter, and may return one or more Organism buddies. To learn more about ChadoBuddies, refer to: :ref:`Chado Buddies Documentation <Chado Buddies>`
 
 .. note::
-    The examples below demonstrate static service calls to the ChadoOrganismBuddy and ChadoOrganismFormElementController classes; however, Dependency Injection is preferred when integrating services, as recommended by Drupal best practices. For more details regarding Injecting ChadoBuddy Services, refer to: `Injecting the Buddy Service Documentation <https://tripaldoc.readthedocs.io/en/latest/dev_guide/biodata/buddies/inject.html#injecting-the-buddy-service>`_
+    The examples below demonstrate static service calls to the ChadoOrganismBuddy and ChadoOrganismFormElementController classes; however, Dependency Injection is preferred when integrating services, as recommended by Drupal best practices. For more details regarding Injecting ChadoBuddy Services, refer to: :ref:`Injecting the Buddy Service Documentation <Injecting the Buddy Service>`
 
 
 

--- a/docs/dev_guide/deprecations/chado_organism_api.rst
+++ b/docs/dev_guide/deprecations/chado_organism_api.rst
@@ -43,7 +43,6 @@ chado_get_organism()
     // matched the input values, and can have one or more records if matches were found.  
     $organism_buddies = $organism_buddy_instance->getOrganism($conditions, []);
 
-
 chado_get_organism_scientific_name()
 ------------------------------------
 
@@ -67,6 +66,11 @@ chado_get_organism_scientific_name()
 
     // Returns a string of the matching organism's scientific name  
     $organism_name = $organism_buddy_instance->getOrganismScientificName($conditions);
+
+chado_get_organism_image_url()
+------------------------------
+
+This function currently has no replacement in Tripal 4.
 
 chado_get_organism_select_options()
 -----------------------------------

--- a/docs/dev_guide/deprecations/chado_organism_api.rst
+++ b/docs/dev_guide/deprecations/chado_organism_api.rst
@@ -6,7 +6,14 @@ Tripal Chado Organism API is deprecated in favour of the ChadoOrganismBuddy and 
 - **Issue** `#2424 <https://github.com/tripal/tripal/issues/2424>`_
 - **PR** `#2426 <https://github.com/tripal/tripal/pull/2426>`_
 
-Methods in ChadoOrganismBuddy class and ChadoOrganismFormElementController class replace the functionality of the existing Chado Organism API methods.
+Methods in ChadoOrganismBuddy and ChadoOrganismFormElementController classes replace the majority of the functionality of the existing Chado Organism API methods. 
+
+Some of these methods can be provided a ChadyBuddyRecord as a parameter, and may return one or more Organism buddies. To learn more about ChadoBuddies, refer to: `Chado Buddies Documentation <https://tripaldoc.readthedocs.io/en/latest/dev_guide/biodata/buddies.html>`_
+
+.. note::
+    The examples below demonstrate static service calls to the ChadoOrganismBuddy and ChadoOrganismFormElementController classes; however, Dependency Injection is preferred when integrating services, as recommended by Drupal best practices. For more details regarding Injecting ChadoBuddy Services, refer to: `Injecting the Buddy Service Documentation <https://tripaldoc.readthedocs.io/en/latest/dev_guide/biodata/buddies/inject.html#injecting-the-buddy-service>`_
+
+
 
 chado_get_organism()
 --------------------
@@ -16,10 +23,10 @@ chado_get_organism()
 .. code-block:: php
 
     $identifiers = [
-        'genus' => 'Lens',
-        'species' => 'culinaris',
+        'genus' => 'Tripalus',  
+        'species' => 'databasica',
     ];
-    $organism = chado_get_organism($identifiers, []);
+    $organism_object = chado_get_organism($identifiers, []);
 
 **After:**
 
@@ -29,10 +36,11 @@ chado_get_organism()
     $organism_buddy_instance = $buddy_service->createInstance('chado_organism_buddy', []);
 
     $conditions = [
-        'organism.genus' => 'Lens',
-        'organism.species' => 'culinaris',
+        'organism.genus' => 'Tripalus',  
+        'organism.species' => 'databasica',
     ];
-    $organism = $organism_buddy_instance->getOrganism($conditions, []);
+    // Retrieves an array of ChadoOrganismBuddy records. This array will be empty if no records matched the input values, and can have one or more records if matches were found.  
+    $organism_buddies = $organism_buddy_instance->getOrganism($conditions, []);
 
 
 chado_get_organism_scientific_name()
@@ -42,7 +50,8 @@ chado_get_organism_scientific_name()
 
 .. code-block:: php
 
-    $organism = chado_get_organism_scientific_name($organism_object);
+    // Returns a string of the matching organism's scientific name  
+    $organism_name = chado_get_organism_scientific_name($organism_object); 
 
 **After:**
 
@@ -51,7 +60,12 @@ chado_get_organism_scientific_name()
     $buddy_service = \Drupal::service('tripal_chado.chado_buddy');
     $organism_buddy_instance = $buddy_service->createInstance('chado_organism_buddy', []);
 
-    $organism = $organism_buddy_instance->getOrganismScientificName($organism_object, []);
+    $conditions = [  
+        'organism.common_name' => 'Tripal',  
+    ];  
+
+    // Returns a string of the matching organism's scientific name  
+    $organism_name = $organism_buddy_instance->getOrganismScientificName($conditions);
 
 chado_get_organism_select_options()
 -----------------------------------
@@ -77,18 +91,42 @@ chado_get_organism_id_from_scientific_name()
 
 **Before:**
 
+By Scientific Name:
+
 .. code-block:: php
 
-    $organism_id = chado_get_organism_id_from_scientific_name($scientific_name, $options);
+    $scientific_name = 'Tripalus databasica';  
+    // Returns an array of organism IDs that match the specified scientific name.  
+    $organism_ids = chado_get_organism_id_from_scientific_name($scientific_name);  
+    
+By Common Name:
+
+.. code-block:: php
+
+    $common_name = 'Tripal';  
+    // Returns an array of organism IDs that match the specified common name.  
+    $organism_ids = chado_get_organism_id_from_scientific_name($common_name, ['check_common_name' => TRUE]);
 
 **After:**
 
+By Scientific Name:  
+
 .. code-block:: php
 
-    $buddy_service = \Drupal::service('tripal_chado.chado_buddy');
-    $organism_buddy_instance = $buddy_service->createInstance('chado_organism_buddy', []);
+    $scientific_name = 'Tripalus databasica';  
+    // Retrieves an array of ChadoOrganismBuddy records. This array will be empty if no records matched the input values, and can have one or more records if matches were found.  
+    $organism_buddies = $organism_buddy_instance->getOrganismFromScientificName($scientific_name);  
+    // Then grab the organism's ID  
+    $organism_id = $organism_buddies[0]->getValue('organism.organism_id');  
 
-    $organism_id = $organism_buddy_instance->getOrganismFromScientificName($scientific_name, $options);
+By Common Name:
+
+.. code-block:: php
+
+    $common_name = 'Tripal';  
+    $organism_buddies = $organism_buddy_instance->getOrganismFromScientificName($common_name, ['check_common_name' => TRUE]);  
+    // Then grab the organism's ID  
+    $organism_id = $organism_buddies[0]->getValue('organism.organism_id');  
 
 chado_abbreviate_infraspecific_rank()
 -------------------------------------
@@ -97,7 +135,8 @@ chado_abbreviate_infraspecific_rank()
 
 .. code-block:: php
 
-    $abbreviation = chado_abbreviate_infraspecific_rank($rank_species);
+    // Returns the abbreviation of an organism's rank.  
+    $rank_abbreviation = chado_abbreviate_infraspecific_rank($rank);
 
 **After:**
 
@@ -106,7 +145,7 @@ chado_abbreviate_infraspecific_rank()
     $buddy_service = \Drupal::service('tripal_chado.chado_buddy');
     $organism_buddy_instance = $buddy_service->createInstance('chado_organism_buddy', []);
 
-    $abbreviation = $organism_buddy_instance->abbreviateInfraspecificRank($rank_species);
+    $rank_abbreviation = $organism_buddy_instance->abbreviateInfraspecificRank($rank);
 
 chado_unabbreviate_infraspecific_rank()
 ----------------------------------------
@@ -115,7 +154,7 @@ chado_unabbreviate_infraspecific_rank()
 
 .. code-block:: php
 
-    $rank = chado_unabbreviate_infraspecific_rank($rank_species);
+    $rank = chado_unabbreviate_infraspecific_rank($rank_abbreviation);
 
 **After:**
 
@@ -124,5 +163,5 @@ chado_unabbreviate_infraspecific_rank()
     $buddy_service = \Drupal::service('tripal_chado.chado_buddy');
     $organism_buddy_instance = $buddy_service->createInstance('chado_organism_buddy', []);
 
-    $rank = $organism_buddy_instance->unabbreviateInfraspecificRank($rank_species);
+    $rank = $organism_buddy_instance->unabbreviateInfraspecificRank($rank_abbreviation);  
 

--- a/docs/dev_guide/deprecations/chado_organism_api.rst
+++ b/docs/dev_guide/deprecations/chado_organism_api.rst
@@ -105,7 +105,8 @@ By Common Name:
 
     $common_name = 'Tripal';  
     // Returns an array of organism IDs that match the specified common name.  
-    $organism_ids = chado_get_organism_id_from_scientific_name($common_name, ['check_common_name' => TRUE]);
+    $organism_ids = chado_get_organism_id_from_scientific_name($common_name,
+      ['check_common_name' => TRUE]);
 
 **After:**
 
@@ -114,7 +115,8 @@ By Scientific Name:
 .. code-block:: php
 
     $scientific_name = 'Tripalus databasica';  
-    // Retrieves an array of ChadoOrganismBuddy records. This array will be empty if no records matched the input values, and can have one or more records if matches were found.  
+    // Retrieves an array of ChadoOrganismBuddy records. This array will be empty if no records matched
+    // the input values, and can have one or more records if matches were found.  
     $organism_buddies = $organism_buddy_instance->getOrganismFromScientificName($scientific_name);  
     // Then grab the organism's ID  
     $organism_id = $organism_buddies[0]->getValue('organism.organism_id');  
@@ -124,7 +126,8 @@ By Common Name:
 .. code-block:: php
 
     $common_name = 'Tripal';  
-    $organism_buddies = $organism_buddy_instance->getOrganismFromScientificName($common_name, ['check_common_name' => TRUE]);  
+    $organism_buddies = $organism_buddy_instance->getOrganismFromScientificName($common_name,
+      ['check_common_name' => TRUE]);  
     // Then grab the organism's ID  
     $organism_id = $organism_buddies[0]->getValue('organism.organism_id');  
 

--- a/docs/dev_guide/deprecations/chado_organism_api.rst
+++ b/docs/dev_guide/deprecations/chado_organism_api.rst
@@ -39,7 +39,8 @@ chado_get_organism()
         'organism.genus' => 'Tripalus',  
         'organism.species' => 'databasica',
     ];
-    // Retrieves an array of ChadoOrganismBuddy records. This array will be empty if no records matched the input values, and can have one or more records if matches were found.  
+    // Retrieves an array of ChadoOrganismBuddy records. This array will be empty if no records matched
+    // the input values, and can have one or more records if matches were found.  
     $organism_buddies = $organism_buddy_instance->getOrganism($conditions, []);
 
 

--- a/docs/dev_guide/deprecations/chado_organism_api.rst
+++ b/docs/dev_guide/deprecations/chado_organism_api.rst
@@ -39,8 +39,8 @@ chado_get_organism()
         'organism.genus' => 'Tripalus',  
         'organism.species' => 'databasica',
     ];
-    // Retrieves an array of ChadoOrganismBuddy records. This array will be empty if no records matched
-    // the input values, and can have one or more records if matches were found.  
+    // Retrieves an array of ChadoOrganismBuddy records. This array will be empty if no records
+    // matched the input values, and can have one or more records if matches were found.  
     $organism_buddies = $organism_buddy_instance->getOrganism($conditions, []);
 
 
@@ -116,8 +116,8 @@ By Scientific Name:
 .. code-block:: php
 
     $scientific_name = 'Tripalus databasica';  
-    // Retrieves an array of ChadoOrganismBuddy records. This array will be empty if no records matched
-    // the input values, and can have one or more records if matches were found.  
+    // Retrieves an array of ChadoOrganismBuddy records. This array will be empty if no records
+    // matched the input values, and can have one or more records if matches were found.  
     $organism_buddies = $organism_buddy_instance->getOrganismFromScientificName($scientific_name);  
     // Then grab the organism's ID  
     $organism_id = $organism_buddies[0]->getValue('organism.organism_id');  

--- a/docs/dev_guide/deprecations/chado_organism_api.rst
+++ b/docs/dev_guide/deprecations/chado_organism_api.rst
@@ -169,3 +169,27 @@ chado_unabbreviate_infraspecific_rank()
 
     $rank = $organism_buddy_instance->unabbreviateInfraspecificRank($rank_abbreviation);  
 
+chado_autocomplete_organism()
+------------------------------
+
+**Before:**
+
+.. code-block:: php
+
+    $organism_autocomplete = chado_autocomplete_organism($text);
+
+**After:**
+
+.. code-block:: php
+
+    use Drupal\tripal_chado\Controller\ChadoOrganismFormElementController;
+
+    ...
+
+    $organism_autocomplete = new ChadoOrganismFormElementController();
+    $request = Request::create(
+        'chado/organism/autocomplete/10',
+        'GET',
+        ['q' => $text]
+    );
+    $organism_autocomplete->handleAutocomplete($request, 5);


### PR DESCRIPTION
Closes issue **#139**

This adds documentation on how to replace the old Chado Organism API methods with the new ChadoOrganismBuddy methods and ChadoOrganismFormElementController as the Chado Organism API methods will be deprecated in tripal 4.0.0-alpha4.

Following documentation is added:

<img width="882" height="939" alt="Screenshot 2026-06-17 at 4 02 48 PM" src="https://github.com/user-attachments/assets/50974967-fbb5-4188-bcf0-55dd6252eef3" />
<img width="891" height="823" alt="Screenshot 2026-06-17 at 4 03 04 PM" src="https://github.com/user-attachments/assets/ad067dac-d4ca-410e-9d17-572fe62f06dc" />
<img width="641" height="331" alt="Screenshot 2026-06-17 at 4 03 17 PM" src="https://github.com/user-attachments/assets/d75fed4a-af92-49da-a6a4-8014ff79950e" />
