### PR TITLE
Update Organism API deprecation documentation to reference tripal:4.0.0-alpha5

### DIFF
--- a/docs/dev_guide/deprecations/chado_organism_api.rst
+++ b/docs/dev_guide/deprecations/chado_organism_api.rst
@@ -1,7 +1,7 @@
 Tripal Chado Organism API is deprecated in favour of the ChadoOrganismBuddy and ChadoOrganismFormElementController
 ===================================================================================================================
 
-- **Deprecated in** tripal 4.0.0-alpha4
+- **Deprecated in** tripal 4.0.0-alpha5
 - **Removed in** tripal 4.1.0
 - **Issue** `#2424 <https://github.com/tripal/tripal/issues/2424>`_
 - **PR** `#2426 <https://github.com/tripal/tripal/pull/2426>`_


### PR DESCRIPTION
Updates the documentation to indicate that the deprecation occurs in: tripal:4.0.0-alpha5.

<img width="767" height="284" alt="Screenshot 2026-07-13 at 11 15 49 AM" src="https://github.com/user-attachments/assets/4d732092-991e-43d8-8c9b-6727935423e6" />
